### PR TITLE
support customResponse

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -205,7 +205,8 @@ proto.request = function* (params) {
     stream: params.stream,
     headers: headers,
     timeout: timeout,
-    writeStream: params.writeStream
+    writeStream: params.writeStream,
+    customResponse: params.customResponse
   };
   var result = yield urllib.requestThunk(url, reqParams);
   debug('response %s %s, got %s, headers: %j', params.method, url, result.status, result.headers);

--- a/lib/object.js
+++ b/lib/object.js
@@ -114,7 +114,8 @@ proto.get = function* (name, file, options) {
       timeout: options.timeout,
       method: 'GET',
       writeStream: writeStream,
-      successStatuses: [200, 206, 304]
+      successStatuses: [200, 206, 304],
+      customResponse: options.customResponse
     });
     if (needDestroy) {
       writeStream.destroy();


### PR DESCRIPTION
读取 Object 时，我需要直接 pipe 到客户端的 response，并根据情况设置 headers，有必要开启 `customResponse`