### PR TITLE
support custom host for objects, improve codes.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -168,7 +168,11 @@ proto.request = function* (params) {
   };
 
   if (params.content || params.stream) {
-    headers['Content-Type'] = mime.lookup(params.mime || path.extname(params.name)) || params.mime;
+    if (params.mime && params.mime.indexOf('/') > 0) {
+      headers['Content-Type'] = params.mime;
+    } else {
+      headers['Content-Type'] = mime.lookup(params.mime || path.extname(params.name));
+    }
     if (params.content) {
       headers['Content-Md5'] = crypto
         .createHash('md5')

--- a/lib/client.js
+++ b/lib/client.js
@@ -51,6 +51,7 @@ function Client(options) {
     internal: false,
     timeout: '60s',
     bucket: null,
+    customHost: null
   };
 
   this.options = {};
@@ -158,17 +159,16 @@ proto.authorization = function (method, resource, headers) {
  */
 
 proto.request = function* (params) {
-  var host = this.options.host;
+  var host = params.host || this.options.host;
   if (params.region) {
     host = this._getRegionHost(params.region);
   }
   var headers = {
-    Date: new Date().toGMTString(),
-    Host: host
+    Date: new Date().toGMTString()
   };
 
   if (params.content || params.stream) {
-    headers['Content-Type'] = mime.lookup(params.mime || path.extname(params.name));
+    headers['Content-Type'] = mime.lookup(params.mime || path.extname(params.name)) || params.mime;
     if (params.content) {
       headers['Content-Md5'] = crypto
         .createHash('md5')
@@ -183,13 +183,6 @@ proto.request = function* (params) {
   copy(params.headers).to(headers);
 
   var resource = params.resource;
-  if (!resource) {
-    if (!this.options.bucket) {
-      throw new Error('Please create a bucket first');
-    }
-    resource = '/' + this.options.bucket + '/' + params.name;
-  }
-
   var authResource = params.authResource || resource;
   headers.authorization = this.authorization(params.method, authResource, headers);
 

--- a/lib/object.js
+++ b/lib/object.js
@@ -29,30 +29,26 @@ var proto = exports;
  */
 
 proto.put = function* (name, file, options) {
-  name = this._objectName(name);
   options = options || {};
   var data = yield* this._getContent(file);
 
-  var headers = options.headers || {};
-  this._convertMetaToHeaders(options.meta, headers);
+  options.headers = options.headers || {};
+  convertMetaToHeaders(options.meta, options.headers);
 
-  if (!headers['Content-Length']) {
+  if (!options.headers['Content-Length']) {
     if (data.size === null) {
       throw new TypeError('streaming upload must given the `Content-Length` header');
     }
-    headers['Content-Length'] = data.size;
+    options.headers['Content-Length'] = data.size;
   }
 
-  var result = yield* this.request({
-    name: name,
-    content: data.content,
-    stream: data.stream,
-    headers: headers,
-    timeout: options.timeout,
-    mime: options.mime,
-    method: 'PUT',
-    successStatuses: [200]
-  });
+  var params = this._objectRequestParams('PUT', name, options);
+  params.mime = options.mime;
+  params.stream = data.stream;
+  params.content = data.content;
+  params.successStatuses = [200];
+
+  var result = yield* this.request(params);
 
   return {
     name: name,
@@ -61,20 +57,15 @@ proto.put = function* (name, file, options) {
 };
 
 proto.head = function* (name, options) {
-  name = this._objectName(name);
-  options = options || {};
-  var result = yield* this.request({
-    name: name,
-    timeout: options.timeout,
-    headers: options.headers,
-    method: 'HEAD',
-    successStatuses: [200, 304]
-  });
+  var params = this._objectRequestParams('HEAD', name, options);
+  params.successStatuses = [200, 304];
+
+  var result = yield* this.request(params);
 
   var data = {
-    status: result.status,
     meta: null,
     res: result.res,
+    status: result.status
   };
 
   if (result.status === 200) {
@@ -91,7 +82,6 @@ proto.head = function* (name, options) {
 };
 
 proto.get = function* (name, file, options) {
-  name = this._objectName(name);
   var writeStream = null;
   var needDestroy = false;
 
@@ -108,14 +98,12 @@ proto.get = function* (name, file, options) {
   options = options || {};
   var result;
   try {
-    result = yield* this.request({
-      name: name,
-      headers: options.headers,
-      timeout: options.timeout,
-      method: 'GET',
-      writeStream: writeStream,
-      successStatuses: [200, 206, 304]
-    });
+    var params = this._objectRequestParams('GET', name, options);
+    params.writeStream = writeStream;
+    params.successStatuses = [200, 206, 304];
+
+    result = yield* this.request(params);
+
     if (needDestroy) {
       writeStream.destroy();
     }
@@ -130,22 +118,18 @@ proto.get = function* (name, file, options) {
   }
 
   return {
-    content: result.data,
     res: result.res,
+    content: result.data
   };
 };
 
 proto.getStream = function* (name, options) {
-  name = this._objectName(name);
   options = options || {};
-  var result = yield* this.request({
-    name: name,
-    headers: options.headers,
-    timeout: options.timeout,
-    method: 'GET',
-    successStatuses: [200, 304],
-    customResponse: true,
-  });
+  var params = this._objectRequestParams('GET', name, options);
+  params.customResponse = true;
+  params.successStatuses = [200, 206, 304];
+
+  var result = yield* this.request(params);
 
   return {
     stream: result.res,
@@ -157,13 +141,10 @@ proto.getStream = function* (name, options) {
 };
 
 proto.delete = function* (name, options) {
-  name = this._objectName(name);
-  var result = yield* this.request({
-    name: name,
-    method: 'DELETE',
-    timeout: options && options.timeout,
-    successStatuses: [204]
-  });
+  var params = this._objectRequestParams('DELETE', name, options);
+  params.successStatuses = [204];
+
+  var result = yield* this.request(params);
 
   return {
     res: result.res
@@ -179,19 +160,18 @@ proto.deleteMulti = function* (names, options) {
     xml += '  <Quiet>false</Quiet>\n';
   }
   for (var i = 0; i < names.length; i++) {
-    xml += '  <Object><Key>' + this._objectName(names[i]) + '</Key></Object>\n';
+    xml += '  <Object><Key>' + pruneObjectName(names[i]) + '</Key></Object>\n';
   }
   xml += '</Delete>';
   debug('delete multi objects: %s', xml);
-  var result = yield this.request({
-    method: 'POST',
-    name: '?delete',
-    content: xml,
-    mime: 'xml',
-    timeout: options.timeout,
-    successStatuses: [200],
-    xmlResponse: true,
-  });
+
+  var params = this._objectRequestParams('POST', '?delete', options);
+  params.mime = 'xml';
+  params.content = xml;
+  params.xmlResponse = true;
+  params.successStatuses = [200];
+
+  var result = yield* this.request(params);
 
   var r = result.data;
   var deleted = r && r.Deleted || null;
@@ -204,38 +184,34 @@ proto.deleteMulti = function* (names, options) {
     });
   }
   return {
-    deleted: deleted,
     res: result.res,
+    deleted: deleted
   };
 };
 
 proto.copy = function* (name, sourceName, options) {
-  name = this._objectName(name);
+  options = options || {};
+  options.headers = options.headers || {};
+  for (var k in options.headers) {
+    options.headers['x-oss-copy-source-' + k.toLowerCase()] = options.headers[k];
+  }
+
+  if (options.meta) {
+    options.headers['x-oss-metadata-directive'] = 'REPLACE';
+  }
+  convertMetaToHeaders(options.meta, options.headers);
+
   if (sourceName[0] !== '/') {
     // copy same bucket object
     sourceName = '/' + this.options.bucket + '/' + sourceName;
   }
-  options = options || {};
-  var headers = options.headers || {};
-  for (var k in headers) {
-    headers['x-oss-copy-source-' + k.toLowerCase()] = headers[k];
-  }
+  options.headers['x-oss-copy-source'] = sourceName;
 
-  if (options.meta) {
-    headers['x-oss-metadata-directive'] = 'REPLACE';
-  }
-  this._convertMetaToHeaders(options.meta, headers);
+  var params = this._objectRequestParams('PUT', name, options);
+  params.xmlResponse = true;
+  params.successStatuses = [200, 304];
 
-  headers['x-oss-copy-source'] = sourceName;
-
-  var result = yield* this.request({
-    method: 'PUT',
-    name: name,
-    headers: headers,
-    timeout: options.timeout,
-    successStatuses: [200, 304],
-    xmlResponse: true,
-  });
+  var result = yield* this.request(params);
 
   var data = result.data;
   if (data) {
@@ -260,14 +236,13 @@ proto.putMeta = function* (name, meta, options) {
 
 proto.list = function* (query, options) {
   // prefix, marker, max-keys, delimiter
-  var result = yield* this.request({
-    method: 'GET',
-    name: '',
-    query: query,
-    timeout: options && options.timeout,
-    successStatuses: [200],
-    xmlResponse: true,
-  });
+
+  var params = this._objectRequestParams('GET', '', options);
+  params.query = query;
+  params.xmlResponse = true;
+  params.successStatuses = [200];
+
+  var result = yield* this.request(params);
 
   var objects = result.data.Contents;
   if (objects) {
@@ -299,53 +274,37 @@ proto.list = function* (query, options) {
     });
   }
   return {
+    res: result.res,
     objects: objects,
     prefixes: prefixes,
-    isTruncated: result.data.IsTruncated === 'true',
     nextMarker: result.data.NextMarker || null,
-    res: result.res
+    isTruncated: result.data.IsTruncated === 'true'
   };
 };
 
 proto.signatureUrl = function (name) {
-  var resourceName = '/' + this.options.bucket + '/' + name;
+  name = pruneObjectName(name);
+  var options = this.options;
+  var resourceName = '/' + options.bucket + '/' + name;
   var expires = utility.timestamp() + 1800;
   var params = [
     'GET',
     '', // md5
     '', // Content-Type
     expires, // Expires
-    resourceName,
+    resourceName
   ];
 
   debug('authorization with params: %j', params);
 
-  var signature = crypto.createHmac('sha1', this.options.accessKeySecret);
+  var signature = crypto.createHmac('sha1', options.accessKeySecret);
   signature = signature.update(params.join('\n')).digest('base64');
-  var url = this._objectUrl(name);
-  return url + '?OSSAccessKeyId=' + encodeURIComponent(this.options.accessKeyId) +
+
+  var url = 'http://';
+  url += options.customHost ? options.customHost + '/' + name : options.host + resourceName;
+
+  return url + '?OSSAccessKeyId=' + encodeURIComponent(options.accessKeyId) +
     '&Expires=' + expires + '&Signature=' + encodeURIComponent(signature);
-};
-
-proto._objectName = function (name) {
-  if (name[0] === '/') {
-    name = name.substring(1);
-  }
-  return name;
-};
-
-proto._objectUrl = function (name) {
-  return 'http://' + this.options.host + '/' + this.options.bucket + '/' + name;
-};
-
-proto._convertMetaToHeaders = function (meta, headers) {
-  if (!meta) {
-    return;
-  }
-
-  for (var k in meta) {
-    headers['x-oss-meta-' + k] = meta[k];
-  }
 };
 
 /**
@@ -385,6 +344,50 @@ proto._getContent = function* (file) {
   content.stream = file;
   return content;
 };
+
+/**
+ * generator request params
+ * @return {Object} params
+ *
+ * @api private
+ */
+
+proto._objectRequestParams = function (method, name, options) {
+  if (!this.options.bucket) {
+    throw new Error('Please create a bucket first');
+  }
+
+  options = options || {};
+  name = pruneObjectName(name);
+  var authResource = '/' + this.options.bucket + '/' + name;
+  var params = {
+    name: name,
+    method: method,
+    timeout: options.timeout,
+    authResource: authResource,
+    host: this.options.customHost || this.options.host,
+    resource: this.options.customHost ? '/' + name : authResource
+  };
+
+  if (options.headers) {
+    params.headers = options.headers;
+  }
+  return params;
+};
+
+function convertMetaToHeaders(meta, headers) {
+  if (!meta) {
+    return;
+  }
+
+  for (var k in meta) {
+    headers['x-oss-meta-' + k] = meta[k];
+  }
+}
+
+function pruneObjectName(name) {
+  return name.replace(/^\/+/, '');
+}
 
 function statFile(filepath) {
   return function (callback) {

--- a/lib/object.js
+++ b/lib/object.js
@@ -301,7 +301,7 @@ proto.signatureUrl = function (name) {
   signature = signature.update(params.join('\n')).digest('base64');
 
   var url = 'http://';
-  url += options.customHost ? options.customHost + '/' + name : options.host + resourceName;
+  url += options.customHost ? (options.customHost + '/' + name) : (options.host + resourceName);
 
   return url + '?OSSAccessKeyId=' + encodeURIComponent(options.accessKeyId) +
     '&Expires=' + expires + '&Signature=' + encodeURIComponent(signature);
@@ -366,7 +366,7 @@ proto._objectRequestParams = function (method, name, options) {
     timeout: options.timeout,
     authResource: authResource,
     host: this.options.customHost || this.options.host,
-    resource: this.options.customHost ? '/' + name : authResource
+    resource: this.options.customHost ? ('/' + name) : authResource
   };
 
   if (options.headers) {

--- a/test/bucket.test.js
+++ b/test/bucket.test.js
@@ -14,9 +14,9 @@
  * Module dependencies.
  */
 
+var oss = require('../');
 var assert = require('assert');
 var utils = require('./utils');
-var oss = require('../');
 var config = require('./config');
 
 describe('bucket.test.js', function () {

--- a/test/object.test.js
+++ b/test/object.test.js
@@ -15,949 +15,957 @@
  */
 
 var fs = require('fs');
+var oss = require('../');
+var cfs = require('co-fs');
 var path = require('path');
 var assert = require('assert');
-var cfs = require('co-fs');
-var Readable = require('stream').Readable;
 var utils = require('./utils');
-var oss = require('../');
 var config = require('./config');
+var Readable = require('stream').Readable;
 
 var tmpdir = path.join(__dirname, '.tmp');
 if (!fs.existsSync(tmpdir)) {
   fs.mkdirSync(tmpdir);
 }
 
-describe('object.test.js', function () {
-  var prefix = utils.prefix;
+describe('object.test.js', testBody());
+describe('object.test.js with custom host', testBody(true));
 
-  before(function* () {
-    this.store = oss(config);
-    this.bucket = 'ali-oss-test-bucket-' + prefix.replace(/[\/\.]/g, '-');
-    this.bucket = this.bucket.substring(0, this.bucket.length - 1);
-    this.region = 'oss-cn-hangzhou';
+function testBody(useCustomHost) {
+  return function () {
+    var prefix = utils.prefix;
 
-    console.log('current buckets: %j',
-      (yield this.store.listBuckets()).buckets.map(function (item) {
-        return item.name + ':' + item.region;
-      })
-    );
+    before(function* () {
+      this.store = oss(config);
+      this.bucket = 'ali-oss-test-bucket-' + prefix.replace(/[\/\.]/g, '-');
+      this.bucket = this.bucket.substring(0, this.bucket.length - 1);
+      this.region = 'oss-cn-hangzhou';
 
-    yield this.store.putBucket(this.bucket, this.region);
-    this.store.useBucket(this.bucket, this.region);
-  });
+      console.log('current buckets: %j',
+        (yield this.store.listBuckets()).buckets.map(function (item) {
+          return item.name + ':' + item.region;
+        })
+      );
 
-  after(function* () {
-    yield utils.cleanBucket(this.store, this.bucket, this.region);
-  });
-
-  describe('put()', function () {
-    it('should add object with local file path', function* () {
-      var name = prefix + 'ali-sdk/oss/put-localfile.js';
-      var object = yield this.store.put(name, __filename);
-      assert.equal(typeof object.res.headers['x-oss-request-id'], 'string');
-      assert.equal(typeof object.res.rt, 'number');
-      assert.equal(object.res.size, 0);
-      assert(object.name, name);
+      yield this.store.putBucket(this.bucket, this.region);
+      this.store.useBucket(this.bucket, this.region);
+      if (useCustomHost) {
+        this.store.options.customHost = this.bucket + '.' + this.store.options.host;
+      }
     });
 
-    it('should add object with content buffer', function* () {
-      var name = prefix + 'ali-sdk/oss/put-buffer';
-      var object = yield this.store.put('/' + name, new Buffer('foo content'));
-      assert.equal(typeof object.res.headers['x-oss-request-id'], 'string');
-      assert.equal(typeof object.res.rt, 'number');
-      assert(object.name, name);
+    after(function* () {
+      yield utils.cleanBucket(this.store, this.bucket, this.region);
     });
 
-    it('should add object with readstream', function* () {
-      var name = prefix + 'ali-sdk/oss/put-readstream';
-      var object = yield this.store.put(name, fs.createReadStream(__filename), {
-        headers: {
-          'Content-Length': (yield cfs.stat(__filename)).size
-        }
+    describe('put()', function () {
+      it('should add object with local file path', function* () {
+        var name = prefix + 'ali-sdk/oss/put-localfile.js';
+        var object = yield this.store.put(name, __filename);
+        assert.equal(typeof object.res.headers['x-oss-request-id'], 'string');
+        assert.equal(typeof object.res.rt, 'number');
+        assert.equal(object.res.size, 0);
+        assert(object.name, name);
       });
-      assert.equal(typeof object.res.headers['x-oss-request-id'], 'string');
-      assert.equal(typeof object.res.rt, 'number');
-      assert.equal(typeof object.res.headers.etag, 'string');
-      assert(object.name, name);
-    });
 
-    it('should throw TypeError when upload stream without Content-Length', function* () {
-      yield utils.throws(function* () {
+      it('should add object with content buffer', function* () {
+        var name = prefix + 'ali-sdk/oss/put-buffer';
+        var object = yield this.store.put('/' + name, new Buffer('foo content'));
+        assert.equal(typeof object.res.headers['x-oss-request-id'], 'string');
+        assert.equal(typeof object.res.rt, 'number');
+        assert(object.name, name);
+      });
+
+      it('should add object with readstream', function* () {
         var name = prefix + 'ali-sdk/oss/put-readstream';
-        yield this.store.put(name, fs.createReadStream(__filename));
-      }.bind(this), function (err) {
-        assert.equal(err.name, 'TypeError');
-        assert.equal(err.message, 'streaming upload must given the `Content-Length` header');
-      });
-    });
-
-    it('should add object with meta', function* () {
-      var name = prefix + 'ali-sdk/oss/put-meta.js';
-      var object = yield this.store.put(name, __filename, {
-        meta: {
-          uid: 1,
-          slus: 'test.html'
-        }
-      });
-      assert.equal(typeof object.res.headers['x-oss-request-id'], 'string');
-      assert.equal(typeof object.res.rt, 'number');
-      assert.equal(object.res.size, 0);
-      assert(object.name, name);
-
-      var info = yield this.store.head(name);
-      assert.deepEqual(info.meta, {
-        uid: '1',
-        slus: 'test.html'
-      });
-      assert.equal(info.status, 200);
-    });
-
-    it('should set Content-Disposition with ascii name', function* () {
-      var name = prefix + 'ali-sdk/oss/put-Content-Disposition.js';
-      var object = yield this.store.put(name, __filename, {
-        headers: {
-          'Content-Disposition': 'ascii-name.js'
-        }
-      });
-      assert(object.name, name);
-      var info = yield this.store.head(name);
-      assert.equal(info.res.headers['content-disposition'], 'ascii-name.js');
-    });
-
-    it('should set Content-Disposition with no-ascii name', function* () {
-      var name = prefix + 'ali-sdk/oss/put-Content-Disposition.js';
-      var object = yield this.store.put(name, __filename, {
-        headers: {
-          'Content-Disposition': encodeURIComponent('non-ascii-名字.js')
-        }
-      });
-      assert(object.name, name);
-      var info = yield this.store.head(name);
-      assert.equal(info.res.headers['content-disposition'], 'non-ascii-%E5%90%8D%E5%AD%97.js');
-    });
-
-    it('should set Expires', function* () {
-      var name = prefix + 'ali-sdk/oss/put-Expires.js';
-      var object = yield this.store.put(name, __filename, {
-        headers: {
-          'Expires': 1000000
-        }
-      });
-      assert(object.name, name);
-      var info = yield this.store.head(name);
-      assert.equal(info.res.headers.expires, '1000000');
-    });
-  });
-
-  describe('head()', function () {
-    before(function* () {
-      this.name = prefix + 'ali-sdk/oss/head-meta.js';
-      var object = yield this.store.put(this.name, __filename, {
-        meta: {
-          uid: 1,
-          pid: '123',
-          slus: 'test.html'
-        }
-      });
-      assert.equal(typeof object.res.headers['x-oss-request-id'], 'string');
-      this.headers = object.res.headers;
-    });
-
-    it('should head not exists object throw NoSuchKeyError', function* () {
-      yield utils.throws(function* () {
-        yield this.store.head(this.name + 'not-exists');
-      }.bind(this), function (err) {
-        assert.equal(err.name, 'NoSuchKeyError');
-        assert.equal(err.status, 404);
-        assert.equal(typeof err.requestId, 'string');
-      });
-    });
-
-    it('should head exists object with If-Modified-Since < object modified time', function* () {
-      var lastYear = new Date(this.headers.date);
-      lastYear.setFullYear(lastYear.getFullYear() - 1);
-      lastYear = lastYear.toGMTString();
-      var info = yield this.store.head(this.name, {
-        headers: {
-          'If-Modified-Since': lastYear
-        }
-      });
-      assert.equal(info.status, 200);
-      assert(info.meta);
-    });
-
-    it('should head exists object with If-Modified-Since = object modified time', function* () {
-      var info = yield this.store.head(this.name, {
-        headers: {
-          'If-Modified-Since': this.headers.date
-        }
-      });
-      assert.equal(info.status, 304);
-      assert.equal(info.meta, null);
-    });
-
-    it('should head exists object with If-Modified-Since > object modified time', function* () {
-      var nextYear = new Date(this.headers.date);
-      nextYear.setFullYear(nextYear.getFullYear() + 1);
-      nextYear = nextYear.toGMTString();
-
-      var info = yield this.store.head(this.name, {
-        headers: {
-          'If-Modified-Since': nextYear
-        }
-      });
-      assert.equal(info.status, 304);
-      assert.equal(info.meta, null);
-    });
-
-    it('should head exists object with If-Unmodified-Since < object modified time', function* () {
-      var lastYear = new Date(this.headers.date);
-      lastYear.setFullYear(lastYear.getFullYear() - 1);
-      lastYear = lastYear.toGMTString();
-      yield utils.throws(function* () {
-        yield this.store.head(this.name, {
+        var object = yield this.store.put(name, fs.createReadStream(__filename), {
           headers: {
-            'If-Unmodified-Since': lastYear
+            'Content-Length': (yield cfs.stat(__filename)).size
           }
         });
-      }.bind(this), function (err) {
-        assert.equal(err.name, 'PreconditionFailedError');
-        assert.equal(err.status, 412);
-      });
-    });
-
-    it('should head exists object with If-Unmodified-Since = object modified time', function* () {
-      var info = yield this.store.head(this.name, {
-        headers: {
-          'If-Unmodified-Since': this.headers.date
-        }
-      });
-      assert.equal(info.status, 200);
-      assert(info.meta);
-    });
-
-    it('should head exists object with If-Unmodified-Since > object modified time', function* () {
-      var nextYear = new Date(this.headers.date);
-      nextYear.setFullYear(nextYear.getFullYear() + 1);
-      nextYear = nextYear.toGMTString();
-
-      var info = yield this.store.head(this.name, {
-        headers: {
-          'If-Unmodified-Since': nextYear
-        }
-      });
-      assert.equal(info.status, 200);
-      assert(info.meta);
-    });
-
-    it('should head exists object with If-Match equal etag', function* () {
-      var info = yield this.store.head(this.name, {
-        headers: {
-          'If-Match': this.headers.etag
-        }
-      });
-      assert.equal(info.meta.uid, '1');
-      assert.equal(info.meta.pid, '123');
-      assert.equal(info.meta.slus, 'test.html');
-      assert.equal(info.status, 200);
-    });
-
-    it('should head exists object with If-Match not equal etag', function* () {
-      yield utils.throws(function* () {
-        yield this.store.head(this.name, {
-          headers: {
-            'If-Match': '"foo-etag"'
-          }
-        });
-      }.bind(this), function (err) {
-        assert.equal(err.name, 'PreconditionFailedError');
-        assert.equal(err.status, 412);
-      });
-    });
-
-    it('should head exists object with If-None-Match equal etag', function* () {
-      var info = yield this.store.head(this.name, {
-        headers: {
-          'If-None-Match': this.headers.etag
-        }
-      });
-      assert.equal(info.meta, null);
-      assert.equal(info.status, 304);
-    });
-
-    it('should head exists object with If-None-Match not equal etag', function* () {
-      var info = yield this.store.head(this.name, {
-        headers: {
-          'If-None-Match': '"foo-etag"'
-        }
-      });
-      assert.equal(info.meta.uid, '1');
-      assert.equal(info.meta.pid, '123');
-      assert.equal(info.meta.slus, 'test.html');
-      assert.equal(info.status, 200);
-    });
-  });
-
-  describe('get()', function () {
-    before(function* () {
-      this.name = prefix + 'ali-sdk/oss/get-meta.js';
-      var object = yield this.store.put(this.name, __filename, {
-        meta: {
-          uid: 1,
-          pid: '123',
-          slus: 'test.html'
-        }
-      });
-      assert.equal(typeof object.res.headers['x-oss-request-id'], 'string');
-      this.headers = object.res.headers;
-    });
-
-    it('should store object to local file', function* () {
-      var savepath = path.join(tmpdir, this.name.replace(/\//g, '-'));
-      var result = yield this.store.get(this.name, savepath);
-      assert.equal(result.res.status, 200);
-      assert.equal(fs.statSync(savepath).size, fs.statSync(__filename).size);
-    });
-
-    it('should throw error when save path parent dir not exists', function* () {
-      var savepath = path.join(tmpdir, 'not-exists', this.name.replace(/\//g, '-'));
-      yield utils.throws(function* () {
-        yield this.store.get(this.name, savepath);
-      }.bind(this), /ENOENT/);
-    });
-
-    it('should store object to writeStream', function* () {
-      var savepath = path.join(tmpdir, this.name.replace(/\//g, '-'));
-      var result = yield this.store.get(this.name, fs.createWriteStream(savepath));
-      assert.equal(result.res.status, 200);
-      assert.equal(fs.statSync(savepath).size, fs.statSync(__filename).size);
-    });
-
-    it('should store not exists object to file', function* () {
-      var savepath = path.join(tmpdir, this.name.replace(/\//g, '-'));
-      yield utils.throws(function* () {
-        yield this.store.get(this.name + 'not-exists', savepath);
-      }.bind(this), function (err) {
-        assert.equal(err.name, 'NoSuchKeyError');
-        assert.equal(err.status, 404);
-        assert(!fs.existsSync(savepath));
-      });
-    });
-
-    it('should throw error when writeStream emit error', function* () {
-      var savepath = path.join(tmpdir, 'not-exists-dir', this.name.replace(/\//g, '-'));
-      yield utils.throws(function* () {
-        yield this.store.get(this.name, fs.createWriteStream(savepath));
-      }.bind(this), /ENOENT/);
-    });
-
-    it('should get object content buffer', function* () {
-      var result = yield this.store.get(this.name);
-      assert(Buffer.isBuffer(result.content), 'content should be Buffer');
-      assert(result.content.toString().indexOf('ali-sdk/oss/get-meta.js') > 0);
-
-      result = yield this.store.get(this.name, null);
-      assert(Buffer.isBuffer(result.content), 'content should be Buffer');
-      assert(result.content.toString().indexOf('ali-sdk/oss/get-meta.js') > 0);
-    });
-
-    it('should throw NoSuchKeyError when object not exists', function* () {
-      var store = this.store;
-      yield utils.throws(function* () {
-        yield store.get('not-exists-key');
-      }.bind(this), function (err) {
-        assert.equal(err.name, 'NoSuchKeyError');
-        assert.equal(err.status, 404);
-        assert.equal(typeof err.requestId, 'string');
-        assert.equal(err.message, 'The specified key does not exist.');
-      });
-    });
-
-    describe('If-Modified-Since header', function () {
-      it('should 200 when If-Modified-Since < object modified time', function* () {
-        var lastYear = new Date(this.headers.date);
-        lastYear.setFullYear(lastYear.getFullYear() - 1);
-        lastYear = lastYear.toGMTString();
-        var result = yield this.store.get(this.name, {
-          headers: {
-            'If-Modified-Since': lastYear
-          }
-        });
-        assert(Buffer.isBuffer(result.content), 'content should be Buffer');
-        assert(result.content.toString().indexOf('ali-sdk/oss/get-meta.js') > 0);
-        assert.equal(result.res.status, 200);
+        assert.equal(typeof object.res.headers['x-oss-request-id'], 'string');
+        assert.equal(typeof object.res.rt, 'number');
+        assert.equal(typeof object.res.headers.etag, 'string');
+        assert(object.name, name);
       });
 
-      it('should 304 when If-Modified-Since = object modified time', function* () {
-        var result = yield this.store.get(this.name, {
-          headers: {
-            'If-Modified-Since': this.headers.date
-          }
-        });
-        assert(Buffer.isBuffer(result.content), 'content should be Buffer');
-        assert.equal(result.content.length, 0);
-        assert.equal(result.res.status, 304);
-      });
-
-      it('should 304 when If-Modified-Since > object modified time', function* () {
-        var nextYear = new Date(this.headers.date);
-        nextYear.setFullYear(nextYear.getFullYear() + 1);
-        nextYear = nextYear.toGMTString();
-        var result = yield this.store.get(this.name, {
-          headers: {
-            'If-Modified-Since': nextYear
-          }
-        });
-        assert(Buffer.isBuffer(result.content), 'content should be Buffer');
-        assert.equal(result.content.length, 0);
-        assert.equal(result.res.status, 304);
-      });
-    });
-
-    describe('If-Unmodified-Since header', function () {
-      it('should throw PreconditionFailedError when If-Unmodified-Since < object modified time', function* () {
-        var lastYear = new Date(this.headers.date);
-        lastYear.setFullYear(lastYear.getFullYear() - 1);
-        lastYear = lastYear.toGMTString();
+      it('should throw TypeError when upload stream without Content-Length', function* () {
         yield utils.throws(function* () {
-          yield this.store.get(this.name, {
-            headers: {
-              'If-Unmodified-Since': lastYear
-            }
-          });
+          var name = prefix + 'ali-sdk/oss/put-readstream';
+          yield this.store.put(name, fs.createReadStream(__filename));
         }.bind(this), function (err) {
-          assert.equal(err.status, 412);
-          assert.equal(err.name, 'PreconditionFailedError');
-          assert.equal(err.message, 'At least one of the pre-conditions you specified did not hold. (condition: If-Unmodified-Since)');
+          assert.equal(err.name, 'TypeError');
+          assert.equal(err.message, 'streaming upload must given the `Content-Length` header');
+        });
+      });
+
+      it('should add object with meta', function* () {
+        var name = prefix + 'ali-sdk/oss/put-meta.js';
+        var object = yield this.store.put(name, __filename, {
+          meta: {
+            uid: 1,
+            slus: 'test.html'
+          }
+        });
+        assert.equal(typeof object.res.headers['x-oss-request-id'], 'string');
+        assert.equal(typeof object.res.rt, 'number');
+        assert.equal(object.res.size, 0);
+        assert(object.name, name);
+
+        var info = yield this.store.head(name);
+        assert.deepEqual(info.meta, {
+          uid: '1',
+          slus: 'test.html'
+        });
+        assert.equal(info.status, 200);
+      });
+
+      it('should set Content-Disposition with ascii name', function* () {
+        var name = prefix + 'ali-sdk/oss/put-Content-Disposition.js';
+        var object = yield this.store.put(name, __filename, {
+          headers: {
+            'Content-Disposition': 'ascii-name.js'
+          }
+        });
+        assert(object.name, name);
+        var info = yield this.store.head(name);
+        assert.equal(info.res.headers['content-disposition'], 'ascii-name.js');
+      });
+
+      it('should set Content-Disposition with no-ascii name', function* () {
+        var name = prefix + 'ali-sdk/oss/put-Content-Disposition.js';
+        var object = yield this.store.put(name, __filename, {
+          headers: {
+            'Content-Disposition': encodeURIComponent('non-ascii-名字.js')
+          }
+        });
+        assert(object.name, name);
+        var info = yield this.store.head(name);
+        assert.equal(info.res.headers['content-disposition'], 'non-ascii-%E5%90%8D%E5%AD%97.js');
+      });
+
+      it('should set Expires', function* () {
+        var name = prefix + 'ali-sdk/oss/put-Expires.js';
+        var object = yield this.store.put(name, __filename, {
+          headers: {
+            'Expires': 1000000
+          }
+        });
+        assert(object.name, name);
+        var info = yield this.store.head(name);
+        assert.equal(info.res.headers.expires, '1000000');
+      });
+    });
+
+    describe('head()', function () {
+      before(function* () {
+        this.name = prefix + 'ali-sdk/oss/head-meta.js';
+        var object = yield this.store.put(this.name, __filename, {
+          meta: {
+            uid: 1,
+            pid: '123',
+            slus: 'test.html'
+          }
+        });
+        assert.equal(typeof object.res.headers['x-oss-request-id'], 'string');
+        this.headers = object.res.headers;
+      });
+
+      it('should head not exists object throw NoSuchKeyError', function* () {
+        yield utils.throws(function* () {
+          yield this.store.head(this.name + 'not-exists');
+        }.bind(this), function (err) {
+          assert.equal(err.name, 'NoSuchKeyError');
+          assert.equal(err.status, 404);
           assert.equal(typeof err.requestId, 'string');
-          assert.equal(typeof err.hostId, 'string');
         });
       });
 
-      it('should 200 when If-Unmodified-Since = object modified time', function* () {
-        var result = yield this.store.get(this.name, {
-          headers: {
-            'If-Unmodified-Since': this.headers.date
-          }
-        });
-        assert.equal(result.res.status, 200);
-        assert(Buffer.isBuffer(result.content), 'content should be Buffer');
-        assert(result.content.toString().indexOf('ali-sdk/oss/get-meta.js') > 0);
-      });
-
-      it('should 200 when If-Unmodified-Since > object modified time', function* () {
-        var nextYear = new Date(this.headers.date);
-        nextYear.setFullYear(nextYear.getFullYear() + 1);
-        nextYear = nextYear.toGMTString();
-        var result = yield this.store.get(this.name, {
-          headers: {
-            'If-Unmodified-Since': nextYear
-          }
-        });
-        assert.equal(result.res.status, 200);
-        assert(Buffer.isBuffer(result.content), 'content should be Buffer');
-        assert(result.content.toString().indexOf('ali-sdk/oss/get-meta.js') > 0);
-      });
-    });
-
-    describe('If-Match header', function () {
-      it('should 200 when If-Match equal object etag', function* () {
-        var result = yield this.store.get(this.name, {
-          headers: {
-            'If-Match': this.headers.etag
-          }
-        });
-        assert.equal(result.res.status, 200);
-      });
-
-      it('should throw PreconditionFailedError when If-Match not equal object etag', function* () {
-        yield utils.throws(function* () {
-          yield this.store.get(this.name, {
-            headers: {
-              'If-Match': 'foo'
-            }
-          });
-        }.bind(this), function (err) {
-          assert.equal(err.name, 'PreconditionFailedError');
-          assert.equal(err.status, 412);
-        });
-      });
-    });
-
-    describe('If-None-Match header', function () {
-      it('should 200 when If-None-Match not equal object etag', function* () {
-        var result = yield this.store.get(this.name, {
-          headers: {
-            'If-None-Match': 'foo'
-          }
-        });
-        assert.equal(result.res.status, 200);
-      });
-
-      it('should 304 when If-None-Match equal object etag', function* () {
-        var result = yield this.store.get(this.name, {
-          headers: {
-            'If-None-Match': this.headers.etag
-          }
-        });
-        assert.equal(result.res.status, 304);
-        assert.equal(result.content.length, 0);
-      });
-    });
-
-    describe('Range header', function () {
-      it('should work with Range header and get top 10 bytes content', function* () {
-        var result = yield this.store.get(this.name, {
-          headers: {
-            Range: 'bytes=0-9'
-          }
-        });
-        assert.equal(result.res.headers['content-length'], '10');
-        assert(Buffer.isBuffer(result.content), 'content should be Buffer');
-        assert.equal(result.content.toString(), '/**!\n * al');
-      });
-    });
-  });
-
-  describe('getStream()', function () {
-    before(function* () {
-      this.name = prefix + 'ali-sdk/oss/get-stream.js';
-      var object = yield this.store.put(this.name, __filename, {
-        meta: {
-          uid: 1,
-          pid: '123',
-          slus: 'test.html'
-        }
-      });
-      this.headers = object.res.headers;
-    });
-
-    it('should get exists object stream', function* () {
-      var result = yield this.store.getStream(this.name);
-      assert.equal(result.res.status, 200);
-      assert(result.stream instanceof Readable);
-      var tmpfile = path.join(tmpdir, 'get-stream.js');
-      var tmpstream = fs.createWriteStream(tmpfile);
-
-      function finish() {
-        return function (callback) {
-          tmpstream.on('finish', callback);
-        };
-      }
-
-      result.stream.pipe(tmpstream);
-      yield finish();
-      assert.equal(fs.readFileSync(tmpfile, 'utf8'), fs.readFileSync(__filename, 'utf8'));
-    });
-
-    it('should throw error when object not exists', function* () {
-      try {
-        yield this.store.getStream(this.name + 'not-exists');
-        throw new Error('should not run this');
-      } catch (err) {
-        assert.equal(err.name, 'NoSuchKeyError');
-      }
-    });
-  });
-
-  describe('delete()', function () {
-    it('should delete exsits object', function* () {
-      var name = prefix + 'ali-sdk/oss/delete.js';
-      yield this.store.put(name, __filename);
-
-      var info = yield this.store.delete(name);
-      assert.equal(info.res.status, 204);
-
-      yield utils.throws(function* () {
-        yield this.store.head(name);
-      }.bind(this), 'NoSuchKeyError');
-    });
-
-    it('should delete not exists object', function* () {
-      var info = yield this.store.delete('not-exists-name');
-      assert.equal(info.res.status, 204);
-    });
-  });
-
-  describe('deleteMulti()', function () {
-    beforeEach(function* () {
-      this.names = [];
-      var name = prefix + 'ali-sdk/oss/deleteMulti0.js';
-      this.names.push(name);
-      yield this.store.put(name, __filename);
-
-      var name = prefix + 'ali-sdk/oss/deleteMulti1.js';
-      this.names.push(name);
-      yield this.store.put(name, __filename);
-
-      var name = prefix + 'ali-sdk/oss/deleteMulti2.js';
-      this.names.push(name);
-      yield this.store.put(name, __filename);
-    });
-
-    it('should delete 3 exists objs', function* () {
-      var result = yield this.store.deleteMulti(this.names);
-      assert.deepEqual(result.deleted, this.names);
-      assert.equal(result.res.status, 200);
-    });
-
-    it('should delete 2 exists and 2 not exists objs', function* () {
-      var result = yield this.store.deleteMulti(this.names.slice(0, 2).concat(['not-exist1', 'not-exist2']));
-      assert.deepEqual(result.deleted, this.names.slice(0, 2).concat(['not-exist1', 'not-exist2']));
-      assert.equal(result.res.status, 200);
-    });
-
-    it('should delete 1 exists objs', function* () {
-      var result = yield this.store.deleteMulti(this.names.slice(0, 1));
-      assert.deepEqual(result.deleted, this.names.slice(0, 1));
-      assert.equal(result.res.status, 200);
-    });
-
-    it('should delete in quiet mode', function* () {
-      var result = yield this.store.deleteMulti(this.names, {
-        quiet: true
-      });
-      assert.equal(result.deleted, null);
-      assert.equal(result.res.status, 200);
-    });
-  });
-
-  describe('copy()', function () {
-    before(function* () {
-      this.name = prefix + 'ali-sdk/oss/copy-meta.js';
-      var object = yield this.store.put(this.name, __filename, {
-        meta: {
-          uid: 1,
-          pid: '123',
-          slus: 'test.html'
-        }
-      });
-      assert.equal(typeof object.res.headers['x-oss-request-id'], 'string');
-      this.headers = object.res.headers;
-    });
-
-    it('should copy object from same bucket', function* () {
-      var name = prefix + 'ali-sdk/oss/copy-new.js';
-      var result = yield this.store.copy(name, this.name);
-      assert.equal(result.res.status, 200);
-      assert.equal(typeof result.data.etag, 'string');
-      assert.equal(typeof result.data.lastModified, 'string');
-
-      var info = yield this.store.head(name);
-      assert.equal(info.meta.uid, '1');
-      assert.equal(info.meta.pid, '123');
-      assert.equal(info.meta.slus, 'test.html');
-      assert.equal(info.status, 200);
-    });
-
-    it('should copy object and set other meta', function* () {
-      var name = prefix + 'ali-sdk/oss/copy-new-2.js';
-      var result = yield this.store.copy(name, this.name, {
-        meta: {
-          uid: '2'
-        }
-      });
-      assert.equal(result.res.status, 200);
-      assert.equal(typeof result.data.etag, 'string');
-      assert.equal(typeof result.data.lastModified, 'string');
-
-      var info = yield this.store.head(name);
-      assert.equal(info.meta.uid, '2');
-      assert(!info.meta.pid);
-      assert(!info.meta.slus);
-      assert.equal(info.status, 200);
-    });
-
-    it('should throw NoSuchKeyError when source object not exists', function* () {
-      yield utils.throws(function* () {
-        yield this.store.copy('new-object', 'not-exists-object');
-      }.bind(this), function (err) {
-        assert.equal(err.name, 'NoSuchKeyError');
-        assert.equal(err.message, 'The specified key does not exist.');
-        assert.equal(err.status, 404);
-      });
-    });
-
-    describe('If-Match header', function () {
-      it('should throw PreconditionFailedError when If-Match not equal source object etag', function* () {
-        yield utils.throws(function* () {
-          yield this.store.copy('new-name', this.name, {
-            headers: {
-              'If-Match': 'foo-bar'
-            }
-          });
-        }.bind(this), function (err) {
-          assert.equal(err.name, 'PreconditionFailedError');
-          assert.equal(err.message, 'At least one of the pre-conditions you specified did not hold. (condition: If-Match)');
-          assert.equal(err.status, 412);
-        });
-      });
-
-      it('should copy object when If-Match equal source object etag', function* () {
-        var name = prefix + 'ali-sdk/oss/copy-new-If-Match.js';
-        var result = yield this.store.copy(name, this.name, {
-          headers: {
-            'If-Match': this.headers.etag
-          }
-        });
-        assert.equal(result.res.status, 200);
-        assert.equal(typeof result.data.etag, 'string');
-        assert.equal(typeof result.data.lastModified, 'string');
-      });
-    });
-
-    describe('If-None-Match header', function () {
-      it('should return 304 when If-None-Match equal source object etag', function* () {
-        var result = yield this.store.copy('new-name', this.name, {
-          headers: {
-            'If-None-Match': this.headers.etag
-          }
-        });
-        assert.equal(result.res.status, 304);
-        assert.equal(result.data, null);
-      });
-
-      it('should copy object when If-None-Match not equal source object etag', function* () {
-        var name = prefix + 'ali-sdk/oss/copy-new-If-None-Match.js';
-        var result = yield this.store.copy(name, this.name, {
-          headers: {
-            'If-None-Match': 'foo-bar'
-          }
-        });
-        assert.equal(result.res.status, 200);
-        assert.equal(typeof result.data.etag, 'string');
-        assert.equal(typeof result.data.lastModified, 'string');
-      });
-    });
-
-    describe('If-Modified-Since header', function () {
-      it('should 304 when If-Modified-Since > source object modified time', function* () {
-        var name = prefix + 'ali-sdk/oss/copy-new-If-Modified-Since.js';
-        var nextYear = new Date(this.headers.date);
-        nextYear.setFullYear(nextYear.getFullYear() + 1);
-        nextYear = nextYear.toGMTString();
-        var result = yield this.store.copy(name, this.name, {
-          headers: {
-            'If-Modified-Since': nextYear
-          }
-        });
-        assert.equal(result.res.status, 304);
-      });
-
-      it('should 304 when If-Modified-Since >= source object modified time', function* () {
-        var name = prefix + 'ali-sdk/oss/copy-new-If-Modified-Since.js';
-        var result = yield this.store.copy(name, this.name, {
-          headers: {
-            'If-Modified-Since': this.headers.date
-          }
-        });
-        assert.equal(result.res.status, 304);
-      });
-
-      it('should 200 when If-Modified-Since < source object modified time', function* () {
-        var name = prefix + 'ali-sdk/oss/copy-new-If-Modified-Since.js';
+      it('should head exists object with If-Modified-Since < object modified time', function* () {
         var lastYear = new Date(this.headers.date);
         lastYear.setFullYear(lastYear.getFullYear() - 1);
         lastYear = lastYear.toGMTString();
-        var result = yield this.store.copy(name, this.name, {
+        var info = yield this.store.head(this.name, {
           headers: {
             'If-Modified-Since': lastYear
           }
         });
-        assert.equal(result.res.status, 200);
+        assert.equal(info.status, 200);
+        assert(info.meta);
       });
-    });
 
-    describe('If-Unmodified-Since header', function () {
-      it('should 200 when If-Unmodified-Since > source object modified time', function* () {
-        var name = prefix + 'ali-sdk/oss/copy-new-If-Unmodified-Since.js';
+      it('should head exists object with If-Modified-Since = object modified time', function* () {
+        var info = yield this.store.head(this.name, {
+          headers: {
+            'If-Modified-Since': this.headers.date
+          }
+        });
+        assert.equal(info.status, 304);
+        assert.equal(info.meta, null);
+      });
+
+      it('should head exists object with If-Modified-Since > object modified time', function* () {
         var nextYear = new Date(this.headers.date);
         nextYear.setFullYear(nextYear.getFullYear() + 1);
         nextYear = nextYear.toGMTString();
-        var result = yield this.store.copy(name, this.name, {
+
+        var info = yield this.store.head(this.name, {
           headers: {
-            'If-Unmodified-Since': nextYear
+            'If-Modified-Since': nextYear
           }
         });
-        assert.equal(result.res.status, 200);
+        assert.equal(info.status, 304);
+        assert.equal(info.meta, null);
       });
 
-      it('should 200 when If-Unmodified-Since >= source object modified time', function* () {
-        var name = prefix + 'ali-sdk/oss/copy-new-If-Unmodified-Since.js';
-        var result = yield this.store.copy(name, this.name, {
-          headers: {
-            'If-Unmodified-Since': this.headers.date
-          }
-        });
-        assert.equal(result.res.status, 200);
-      });
-
-      it('should throw PreconditionFailedError when If-Unmodified-Since < source object modified time', function* () {
-        var name = prefix + 'ali-sdk/oss/copy-new-If-Unmodified-Since.js';
+      it('should head exists object with If-Unmodified-Since < object modified time', function* () {
         var lastYear = new Date(this.headers.date);
         lastYear.setFullYear(lastYear.getFullYear() - 1);
         lastYear = lastYear.toGMTString();
         yield utils.throws(function* () {
-          yield this.store.copy(name, this.name, {
+          yield this.store.head(this.name, {
             headers: {
               'If-Unmodified-Since': lastYear
             }
           });
         }.bind(this), function (err) {
           assert.equal(err.name, 'PreconditionFailedError');
-          assert.equal(err.message, 'At least one of the pre-conditions you specified did not hold. (condition: If-Unmodified-Since)');
           assert.equal(err.status, 412);
         });
       });
-    });
-  });
 
-  describe('putMeta()', function () {
-    before(function* () {
-      this.name = prefix + 'ali-sdk/oss/putMeta.js';
-      var object = yield this.store.put(this.name, __filename, {
-        meta: {
-          uid: 1,
-          pid: '123',
-          slus: 'test.html'
+      it('should head exists object with If-Unmodified-Since = object modified time', function* () {
+        var info = yield this.store.head(this.name, {
+          headers: {
+            'If-Unmodified-Since': this.headers.date
+          }
+        });
+        assert.equal(info.status, 200);
+        assert(info.meta);
+      });
+
+      it('should head exists object with If-Unmodified-Since > object modified time', function* () {
+        var nextYear = new Date(this.headers.date);
+        nextYear.setFullYear(nextYear.getFullYear() + 1);
+        nextYear = nextYear.toGMTString();
+
+        var info = yield this.store.head(this.name, {
+          headers: {
+            'If-Unmodified-Since': nextYear
+          }
+        });
+        assert.equal(info.status, 200);
+        assert(info.meta);
+      });
+
+      it('should head exists object with If-Match equal etag', function* () {
+        var info = yield this.store.head(this.name, {
+          headers: {
+            'If-Match': this.headers.etag
+          }
+        });
+        assert.equal(info.meta.uid, '1');
+        assert.equal(info.meta.pid, '123');
+        assert.equal(info.meta.slus, 'test.html');
+        assert.equal(info.status, 200);
+      });
+
+      it('should head exists object with If-Match not equal etag', function* () {
+        yield utils.throws(function* () {
+          yield this.store.head(this.name, {
+            headers: {
+              'If-Match': '"foo-etag"'
+            }
+          });
+        }.bind(this), function (err) {
+          assert.equal(err.name, 'PreconditionFailedError');
+          assert.equal(err.status, 412);
+        });
+      });
+
+      it('should head exists object with If-None-Match equal etag', function* () {
+        var info = yield this.store.head(this.name, {
+          headers: {
+            'If-None-Match': this.headers.etag
+          }
+        });
+        assert.equal(info.meta, null);
+        assert.equal(info.status, 304);
+      });
+
+      it('should head exists object with If-None-Match not equal etag', function* () {
+        var info = yield this.store.head(this.name, {
+          headers: {
+            'If-None-Match': '"foo-etag"'
+          }
+        });
+        assert.equal(info.meta.uid, '1');
+        assert.equal(info.meta.pid, '123');
+        assert.equal(info.meta.slus, 'test.html');
+        assert.equal(info.status, 200);
+      });
+    });
+
+    describe('get()', function () {
+      before(function* () {
+        this.name = prefix + 'ali-sdk/oss/get-meta.js';
+        var object = yield this.store.put(this.name, __filename, {
+          meta: {
+            uid: 1,
+            pid: '123',
+            slus: 'test.html'
+          }
+        });
+        assert.equal(typeof object.res.headers['x-oss-request-id'], 'string');
+        this.headers = object.res.headers;
+      });
+
+      it('should store object to local file', function* () {
+        var savepath = path.join(tmpdir, this.name.replace(/\//g, '-'));
+        var result = yield this.store.get(this.name, savepath);
+        assert.equal(result.res.status, 200);
+        assert.equal(fs.statSync(savepath).size, fs.statSync(__filename).size);
+      });
+
+      it('should throw error when save path parent dir not exists', function* () {
+        var savepath = path.join(tmpdir, 'not-exists', this.name.replace(/\//g, '-'));
+        yield utils.throws(function* () {
+          yield this.store.get(this.name, savepath);
+        }.bind(this), /ENOENT/);
+      });
+
+      it('should store object to writeStream', function* () {
+        var savepath = path.join(tmpdir, this.name.replace(/\//g, '-'));
+        var result = yield this.store.get(this.name, fs.createWriteStream(savepath));
+        assert.equal(result.res.status, 200);
+        assert.equal(fs.statSync(savepath).size, fs.statSync(__filename).size);
+      });
+
+      it('should store not exists object to file', function* () {
+        var savepath = path.join(tmpdir, this.name.replace(/\//g, '-'));
+        yield utils.throws(function* () {
+          yield this.store.get(this.name + 'not-exists', savepath);
+        }.bind(this), function (err) {
+          assert.equal(err.name, 'NoSuchKeyError');
+          assert.equal(err.status, 404);
+          assert(!fs.existsSync(savepath));
+        });
+      });
+
+      it('should throw error when writeStream emit error', function* () {
+        var savepath = path.join(tmpdir, 'not-exists-dir', this.name.replace(/\//g, '-'));
+        yield utils.throws(function* () {
+          yield this.store.get(this.name, fs.createWriteStream(savepath));
+        }.bind(this), /ENOENT/);
+      });
+
+      it('should get object content buffer', function* () {
+        var result = yield this.store.get(this.name);
+        assert(Buffer.isBuffer(result.content), 'content should be Buffer');
+        assert(result.content.toString().indexOf('ali-sdk/oss/get-meta.js') > 0);
+
+        result = yield this.store.get(this.name, null);
+        assert(Buffer.isBuffer(result.content), 'content should be Buffer');
+        assert(result.content.toString().indexOf('ali-sdk/oss/get-meta.js') > 0);
+      });
+
+      it('should throw NoSuchKeyError when object not exists', function* () {
+        var store = this.store;
+        yield utils.throws(function* () {
+          yield store.get('not-exists-key');
+        }.bind(this), function (err) {
+          assert.equal(err.name, 'NoSuchKeyError');
+          assert.equal(err.status, 404);
+          assert.equal(typeof err.requestId, 'string');
+          assert.equal(err.message, 'The specified key does not exist.');
+        });
+      });
+
+      describe('If-Modified-Since header', function () {
+        it('should 200 when If-Modified-Since < object modified time', function* () {
+          var lastYear = new Date(this.headers.date);
+          lastYear.setFullYear(lastYear.getFullYear() - 1);
+          lastYear = lastYear.toGMTString();
+          var result = yield this.store.get(this.name, {
+            headers: {
+              'If-Modified-Since': lastYear
+            }
+          });
+          assert(Buffer.isBuffer(result.content), 'content should be Buffer');
+          assert(result.content.toString().indexOf('ali-sdk/oss/get-meta.js') > 0);
+          assert.equal(result.res.status, 200);
+        });
+
+        it('should 304 when If-Modified-Since = object modified time', function* () {
+          var result = yield this.store.get(this.name, {
+            headers: {
+              'If-Modified-Since': this.headers.date
+            }
+          });
+          assert(Buffer.isBuffer(result.content), 'content should be Buffer');
+          assert.equal(result.content.length, 0);
+          assert.equal(result.res.status, 304);
+        });
+
+        it('should 304 when If-Modified-Since > object modified time', function* () {
+          var nextYear = new Date(this.headers.date);
+          nextYear.setFullYear(nextYear.getFullYear() + 1);
+          nextYear = nextYear.toGMTString();
+          var result = yield this.store.get(this.name, {
+            headers: {
+              'If-Modified-Since': nextYear
+            }
+          });
+          assert(Buffer.isBuffer(result.content), 'content should be Buffer');
+          assert.equal(result.content.length, 0);
+          assert.equal(result.res.status, 304);
+        });
+      });
+
+      describe('If-Unmodified-Since header', function () {
+        it('should throw PreconditionFailedError when If-Unmodified-Since < object modified time', function* () {
+          var lastYear = new Date(this.headers.date);
+          lastYear.setFullYear(lastYear.getFullYear() - 1);
+          lastYear = lastYear.toGMTString();
+          yield utils.throws(function* () {
+            yield this.store.get(this.name, {
+              headers: {
+                'If-Unmodified-Since': lastYear
+              }
+            });
+          }.bind(this), function (err) {
+            assert.equal(err.status, 412);
+            assert.equal(err.name, 'PreconditionFailedError');
+            assert.equal(err.message, 'At least one of the pre-conditions you specified did not hold. (condition: If-Unmodified-Since)');
+            assert.equal(typeof err.requestId, 'string');
+            assert.equal(typeof err.hostId, 'string');
+          });
+        });
+
+        it('should 200 when If-Unmodified-Since = object modified time', function* () {
+          var result = yield this.store.get(this.name, {
+            headers: {
+              'If-Unmodified-Since': this.headers.date
+            }
+          });
+          assert.equal(result.res.status, 200);
+          assert(Buffer.isBuffer(result.content), 'content should be Buffer');
+          assert(result.content.toString().indexOf('ali-sdk/oss/get-meta.js') > 0);
+        });
+
+        it('should 200 when If-Unmodified-Since > object modified time', function* () {
+          var nextYear = new Date(this.headers.date);
+          nextYear.setFullYear(nextYear.getFullYear() + 1);
+          nextYear = nextYear.toGMTString();
+          var result = yield this.store.get(this.name, {
+            headers: {
+              'If-Unmodified-Since': nextYear
+            }
+          });
+          assert.equal(result.res.status, 200);
+          assert(Buffer.isBuffer(result.content), 'content should be Buffer');
+          assert(result.content.toString().indexOf('ali-sdk/oss/get-meta.js') > 0);
+        });
+      });
+
+      describe('If-Match header', function () {
+        it('should 200 when If-Match equal object etag', function* () {
+          var result = yield this.store.get(this.name, {
+            headers: {
+              'If-Match': this.headers.etag
+            }
+          });
+          assert.equal(result.res.status, 200);
+        });
+
+        it('should throw PreconditionFailedError when If-Match not equal object etag', function* () {
+          yield utils.throws(function* () {
+            yield this.store.get(this.name, {
+              headers: {
+                'If-Match': 'foo'
+              }
+            });
+          }.bind(this), function (err) {
+            assert.equal(err.name, 'PreconditionFailedError');
+            assert.equal(err.status, 412);
+          });
+        });
+      });
+
+      describe('If-None-Match header', function () {
+        it('should 200 when If-None-Match not equal object etag', function* () {
+          var result = yield this.store.get(this.name, {
+            headers: {
+              'If-None-Match': 'foo'
+            }
+          });
+          assert.equal(result.res.status, 200);
+        });
+
+        it('should 304 when If-None-Match equal object etag', function* () {
+          var result = yield this.store.get(this.name, {
+            headers: {
+              'If-None-Match': this.headers.etag
+            }
+          });
+          assert.equal(result.res.status, 304);
+          assert.equal(result.content.length, 0);
+        });
+      });
+
+      describe('Range header', function () {
+        it('should work with Range header and get top 10 bytes content', function* () {
+          var result = yield this.store.get(this.name, {
+            headers: {
+              Range: 'bytes=0-9'
+            }
+          });
+          assert.equal(result.res.headers['content-length'], '10');
+          assert(Buffer.isBuffer(result.content), 'content should be Buffer');
+          assert.equal(result.content.toString(), '/**!\n * al');
+        });
+      });
+    });
+
+    describe('getStream()', function () {
+      before(function* () {
+        this.name = prefix + 'ali-sdk/oss/get-stream.js';
+        var object = yield this.store.put(this.name, __filename, {
+          meta: {
+            uid: 1,
+            pid: '123',
+            slus: 'test.html'
+          }
+        });
+        this.headers = object.res.headers;
+      });
+
+      it('should get exists object stream', function* () {
+        var result = yield this.store.getStream(this.name);
+        assert.equal(result.res.status, 200);
+        assert(result.stream instanceof Readable);
+        var tmpfile = path.join(tmpdir, 'get-stream.js');
+        var tmpstream = fs.createWriteStream(tmpfile);
+
+        function finish() {
+          return function (callback) {
+            tmpstream.on('finish', callback);
+          };
+        }
+
+        result.stream.pipe(tmpstream);
+        yield finish();
+        assert.equal(fs.readFileSync(tmpfile, 'utf8'), fs.readFileSync(__filename, 'utf8'));
+      });
+
+      it('should throw error when object not exists', function* () {
+        try {
+          yield this.store.getStream(this.name + 'not-exists');
+          throw new Error('should not run this');
+        } catch (err) {
+          assert.equal(err.name, 'NoSuchKeyError');
         }
       });
-      assert.equal(typeof object.res.headers['x-oss-request-id'], 'string');
-      this.headers = object.res.headers;
     });
 
-    it('should update exists object meta', function* () {
-      yield this.store.putMeta(this.name, {
-        uid: '2'
+    describe('delete()', function () {
+      it('should delete exsits object', function* () {
+        var name = prefix + 'ali-sdk/oss/delete.js';
+        yield this.store.put(name, __filename);
+
+        var info = yield this.store.delete(name);
+        assert.equal(info.res.status, 204);
+
+        yield utils.throws(function* () {
+          yield this.store.head(name);
+        }.bind(this), 'NoSuchKeyError');
       });
-      var info = yield this.store.head(this.name);
-      assert.equal(info.meta.uid, '2');
-      assert(!info.meta.pid);
-      assert(!info.meta.slus);
+
+      it('should delete not exists object', function* () {
+        var info = yield this.store.delete('not-exists-name');
+        assert.equal(info.res.status, 204);
+      });
     });
 
-    it('should throw NoSuchKeyError when update not exists object meta', function* () {
-      yield utils.throws(function* () {
-        yield this.store.putMeta(this.name + 'not-exists', {
+    describe('deleteMulti()', function () {
+      beforeEach(function* () {
+        this.names = [];
+        var name = prefix + 'ali-sdk/oss/deleteMulti0.js';
+        this.names.push(name);
+        yield this.store.put(name, __filename);
+
+        var name = prefix + 'ali-sdk/oss/deleteMulti1.js';
+        this.names.push(name);
+        yield this.store.put(name, __filename);
+
+        var name = prefix + 'ali-sdk/oss/deleteMulti2.js';
+        this.names.push(name);
+        yield this.store.put(name, __filename);
+      });
+
+      it('should delete 3 exists objs', function* () {
+        var result = yield this.store.deleteMulti(this.names);
+        assert.deepEqual(result.deleted, this.names);
+        assert.equal(result.res.status, 200);
+      });
+
+      it('should delete 2 exists and 2 not exists objs', function* () {
+        var result = yield this.store.deleteMulti(this.names.slice(0, 2).concat(['not-exist1', 'not-exist2']));
+        assert.deepEqual(result.deleted, this.names.slice(0, 2).concat(['not-exist1', 'not-exist2']));
+        assert.equal(result.res.status, 200);
+      });
+
+      it('should delete 1 exists objs', function* () {
+        var result = yield this.store.deleteMulti(this.names.slice(0, 1));
+        assert.deepEqual(result.deleted, this.names.slice(0, 1));
+        assert.equal(result.res.status, 200);
+      });
+
+      it('should delete in quiet mode', function* () {
+        var result = yield this.store.deleteMulti(this.names, {
+          quiet: true
+        });
+        assert.equal(result.deleted, null);
+        assert.equal(result.res.status, 200);
+      });
+    });
+
+    describe('copy()', function () {
+      before(function* () {
+        this.name = prefix + 'ali-sdk/oss/copy-meta.js';
+        var object = yield this.store.put(this.name, __filename, {
+          meta: {
+            uid: 1,
+            pid: '123',
+            slus: 'test.html'
+          }
+        });
+        assert.equal(typeof object.res.headers['x-oss-request-id'], 'string');
+        this.headers = object.res.headers;
+      });
+
+      it('should copy object from same bucket', function* () {
+        var name = prefix + 'ali-sdk/oss/copy-new.js';
+        var result = yield this.store.copy(name, this.name);
+        assert.equal(result.res.status, 200);
+        assert.equal(typeof result.data.etag, 'string');
+        assert.equal(typeof result.data.lastModified, 'string');
+
+        var info = yield this.store.head(name);
+        assert.equal(info.meta.uid, '1');
+        assert.equal(info.meta.pid, '123');
+        assert.equal(info.meta.slus, 'test.html');
+        assert.equal(info.status, 200);
+      });
+
+      it('should copy object and set other meta', function* () {
+        var name = prefix + 'ali-sdk/oss/copy-new-2.js';
+        var result = yield this.store.copy(name, this.name, {
+          meta: {
+            uid: '2'
+          }
+        });
+        assert.equal(result.res.status, 200);
+        assert.equal(typeof result.data.etag, 'string');
+        assert.equal(typeof result.data.lastModified, 'string');
+
+        var info = yield this.store.head(name);
+        assert.equal(info.meta.uid, '2');
+        assert(!info.meta.pid);
+        assert(!info.meta.slus);
+        assert.equal(info.status, 200);
+      });
+
+      it('should throw NoSuchKeyError when source object not exists', function* () {
+        yield utils.throws(function* () {
+          yield this.store.copy('new-object', 'not-exists-object');
+        }.bind(this), function (err) {
+          assert.equal(err.name, 'NoSuchKeyError');
+          assert.equal(err.message, 'The specified key does not exist.');
+          assert.equal(err.status, 404);
+        });
+      });
+
+      describe('If-Match header', function () {
+        it('should throw PreconditionFailedError when If-Match not equal source object etag', function* () {
+          yield utils.throws(function* () {
+            yield this.store.copy('new-name', this.name, {
+              headers: {
+                'If-Match': 'foo-bar'
+              }
+            });
+          }.bind(this), function (err) {
+            assert.equal(err.name, 'PreconditionFailedError');
+            assert.equal(err.message, 'At least one of the pre-conditions you specified did not hold. (condition: If-Match)');
+            assert.equal(err.status, 412);
+          });
+        });
+
+        it('should copy object when If-Match equal source object etag', function* () {
+          var name = prefix + 'ali-sdk/oss/copy-new-If-Match.js';
+          var result = yield this.store.copy(name, this.name, {
+            headers: {
+              'If-Match': this.headers.etag
+            }
+          });
+          assert.equal(result.res.status, 200);
+          assert.equal(typeof result.data.etag, 'string');
+          assert.equal(typeof result.data.lastModified, 'string');
+        });
+      });
+
+      describe('If-None-Match header', function () {
+        it('should return 304 when If-None-Match equal source object etag', function* () {
+          var result = yield this.store.copy('new-name', this.name, {
+            headers: {
+              'If-None-Match': this.headers.etag
+            }
+          });
+          assert.equal(result.res.status, 304);
+          assert.equal(result.data, null);
+        });
+
+        it('should copy object when If-None-Match not equal source object etag', function* () {
+          var name = prefix + 'ali-sdk/oss/copy-new-If-None-Match.js';
+          var result = yield this.store.copy(name, this.name, {
+            headers: {
+              'If-None-Match': 'foo-bar'
+            }
+          });
+          assert.equal(result.res.status, 200);
+          assert.equal(typeof result.data.etag, 'string');
+          assert.equal(typeof result.data.lastModified, 'string');
+        });
+      });
+
+      describe('If-Modified-Since header', function () {
+        it('should 304 when If-Modified-Since > source object modified time', function* () {
+          var name = prefix + 'ali-sdk/oss/copy-new-If-Modified-Since.js';
+          var nextYear = new Date(this.headers.date);
+          nextYear.setFullYear(nextYear.getFullYear() + 1);
+          nextYear = nextYear.toGMTString();
+          var result = yield this.store.copy(name, this.name, {
+            headers: {
+              'If-Modified-Since': nextYear
+            }
+          });
+          assert.equal(result.res.status, 304);
+        });
+
+        it('should 304 when If-Modified-Since >= source object modified time', function* () {
+          var name = prefix + 'ali-sdk/oss/copy-new-If-Modified-Since.js';
+          var result = yield this.store.copy(name, this.name, {
+            headers: {
+              'If-Modified-Since': this.headers.date
+            }
+          });
+          assert.equal(result.res.status, 304);
+        });
+
+        it('should 200 when If-Modified-Since < source object modified time', function* () {
+          var name = prefix + 'ali-sdk/oss/copy-new-If-Modified-Since.js';
+          var lastYear = new Date(this.headers.date);
+          lastYear.setFullYear(lastYear.getFullYear() - 1);
+          lastYear = lastYear.toGMTString();
+          var result = yield this.store.copy(name, this.name, {
+            headers: {
+              'If-Modified-Since': lastYear
+            }
+          });
+          assert.equal(result.res.status, 200);
+        });
+      });
+
+      describe('If-Unmodified-Since header', function () {
+        it('should 200 when If-Unmodified-Since > source object modified time', function* () {
+          var name = prefix + 'ali-sdk/oss/copy-new-If-Unmodified-Since.js';
+          var nextYear = new Date(this.headers.date);
+          nextYear.setFullYear(nextYear.getFullYear() + 1);
+          nextYear = nextYear.toGMTString();
+          var result = yield this.store.copy(name, this.name, {
+            headers: {
+              'If-Unmodified-Since': nextYear
+            }
+          });
+          assert.equal(result.res.status, 200);
+        });
+
+        it('should 200 when If-Unmodified-Since >= source object modified time', function* () {
+          var name = prefix + 'ali-sdk/oss/copy-new-If-Unmodified-Since.js';
+          var result = yield this.store.copy(name, this.name, {
+            headers: {
+              'If-Unmodified-Since': this.headers.date
+            }
+          });
+          assert.equal(result.res.status, 200);
+        });
+
+        it('should throw PreconditionFailedError when If-Unmodified-Since < source object modified time', function* () {
+          var name = prefix + 'ali-sdk/oss/copy-new-If-Unmodified-Since.js';
+          var lastYear = new Date(this.headers.date);
+          lastYear.setFullYear(lastYear.getFullYear() - 1);
+          lastYear = lastYear.toGMTString();
+          yield utils.throws(function* () {
+            yield this.store.copy(name, this.name, {
+              headers: {
+                'If-Unmodified-Since': lastYear
+              }
+            });
+          }.bind(this), function (err) {
+            assert.equal(err.name, 'PreconditionFailedError');
+            assert.equal(err.message, 'At least one of the pre-conditions you specified did not hold. (condition: If-Unmodified-Since)');
+            assert.equal(err.status, 412);
+          });
+        });
+      });
+    });
+
+    describe('putMeta()', function () {
+      before(function* () {
+        this.name = prefix + 'ali-sdk/oss/putMeta.js';
+        var object = yield this.store.put(this.name, __filename, {
+          meta: {
+            uid: 1,
+            pid: '123',
+            slus: 'test.html'
+          }
+        });
+        assert.equal(typeof object.res.headers['x-oss-request-id'], 'string');
+        this.headers = object.res.headers;
+      });
+
+      it('should update exists object meta', function* () {
+        yield this.store.putMeta(this.name, {
           uid: '2'
         });
-      }.bind(this), function (err) {
-        assert.equal(err.name, 'NoSuchKeyError');
-        assert.equal(err.status, 404);
+        var info = yield this.store.head(this.name);
+        assert.equal(info.meta.uid, '2');
+        assert(!info.meta.pid);
+        assert(!info.meta.slus);
+      });
+
+      it('should throw NoSuchKeyError when update not exists object meta', function* () {
+        yield utils.throws(function* () {
+          yield this.store.putMeta(this.name + 'not-exists', {
+            uid: '2'
+          });
+        }.bind(this), function (err) {
+          assert.equal(err.name, 'NoSuchKeyError');
+          assert.equal(err.status, 404);
+        });
       });
     });
-  });
 
-  describe('list()', function () {
-    // oss.jpg
-    // fun/test.jpg
-    // fun/movie/001.avi
-    // fun/movie/007.avi
-    before(function* () {
-      var listPrefix =  prefix + 'ali-sdk/list/';
-      yield this.store.put(listPrefix + 'oss.jpg', new Buffer('oss.jpg'));
-      yield this.store.put(listPrefix + 'fun/test.jpg', new Buffer('fun/test.jpg'));
-      yield this.store.put(listPrefix + 'fun/movie/001.avi', new Buffer('fun/movie/001.avi'));
-      yield this.store.put(listPrefix + 'fun/movie/007.avi', new Buffer('fun/movie/007.avi'));
-      this.listPrefix = listPrefix;
+    describe('list()', function () {
+      // oss.jpg
+      // fun/test.jpg
+      // fun/movie/001.avi
+      // fun/movie/007.avi
+      before(function* () {
+        var listPrefix =  prefix + 'ali-sdk/list/';
+        yield this.store.put(listPrefix + 'oss.jpg', new Buffer('oss.jpg'));
+        yield this.store.put(listPrefix + 'fun/test.jpg', new Buffer('fun/test.jpg'));
+        yield this.store.put(listPrefix + 'fun/movie/001.avi', new Buffer('fun/movie/001.avi'));
+        yield this.store.put(listPrefix + 'fun/movie/007.avi', new Buffer('fun/movie/007.avi'));
+        this.listPrefix = listPrefix;
+      });
+
+      function checkObjectProperties(obj) {
+        assert.equal(typeof obj.name, 'string');
+        assert.equal(typeof obj.lastModified, 'string');
+        assert.equal(typeof obj.etag, 'string');
+        assert.equal(obj.type, 'Normal');
+        assert.equal(typeof obj.size, 'number');
+        assert.equal(obj.storageClass, 'Standard');
+        assert.equal(typeof obj.owner, 'object');
+        assert.equal(typeof obj.owner.id, 'string');
+        assert.equal(typeof obj.owner.displayName, 'string');
+      }
+
+      it('should list only 1 object', function* () {
+        var result = yield this.store.list({
+          'max-keys': 1
+        });
+        assert.equal(result.objects.length, 1);
+        result.objects.map(checkObjectProperties);
+        assert.equal(typeof result.nextMarker, 'string');
+        assert(result.isTruncated);
+        assert.equal(result.prefixes, null);
+      });
+
+      it('should list top 3 objects', function* () {
+        var result = yield this.store.list({
+          'max-keys': 3
+        });
+        assert.equal(result.objects.length, 3);
+        result.objects.map(checkObjectProperties);
+        assert.equal(typeof result.nextMarker, 'string');
+        assert(result.isTruncated);
+        assert.equal(result.prefixes, null);
+
+        // next 2
+        var result2 = yield this.store.list({
+          'max-keys': 2,
+          marker: result.nextMarker
+        });
+        assert.equal(result2.objects.length, 2);
+        result.objects.map(checkObjectProperties);
+        assert.equal(typeof result2.nextMarker, 'string');
+        assert(result2.isTruncated);
+        assert.equal(result2.prefixes, null);
+      });
+
+      it('should list with prefix', function* () {
+        var result = yield this.store.list({
+          prefix: this.listPrefix + 'fun/movie/',
+        });
+        assert.equal(result.objects.length, 2);
+        result.objects.map(checkObjectProperties);
+        assert.equal(result.nextMarker, null);
+        assert(!result.isTruncated);
+        assert.equal(result.prefixes, null);
+
+        var result = yield this.store.list({
+          prefix: this.listPrefix + 'fun/movie',
+        });
+        assert.equal(result.objects.length, 2);
+        result.objects.map(checkObjectProperties);
+        assert.equal(result.nextMarker, null);
+        assert(!result.isTruncated);
+        assert.equal(result.prefixes, null);
+      });
+
+      it('should list current dir files only', function* () {
+        var result = yield this.store.list({
+          prefix: this.listPrefix,
+          delimiter: '/'
+        });
+        assert.equal(result.objects.length, 1);
+        result.objects.map(checkObjectProperties);
+        assert.equal(result.nextMarker, null);
+        assert(!result.isTruncated);
+        assert.deepEqual(result.prefixes, [this.listPrefix + 'fun/']);
+
+        var result = yield this.store.list({
+          prefix: this.listPrefix + 'fun/',
+          delimiter: '/'
+        });
+        assert.equal(result.objects.length, 1);
+        result.objects.map(checkObjectProperties);
+        assert.equal(result.nextMarker, null);
+        assert(!result.isTruncated);
+        assert.deepEqual(result.prefixes, [this.listPrefix + 'fun/movie/']);
+
+        var result = yield this.store.list({
+          prefix: this.listPrefix + 'fun/movie/',
+          delimiter: '/'
+        });
+        assert.equal(result.objects.length, 2);
+        result.objects.map(checkObjectProperties);
+        assert.equal(result.nextMarker, null);
+        assert(!result.isTruncated);
+        assert.equal(result.prefixes, null);
+      });
     });
-
-    function checkObjectProperties(obj) {
-      assert.equal(typeof obj.name, 'string');
-      assert.equal(typeof obj.lastModified, 'string');
-      assert.equal(typeof obj.etag, 'string');
-      assert.equal(obj.type, 'Normal');
-      assert.equal(typeof obj.size, 'number');
-      assert.equal(obj.storageClass, 'Standard');
-      assert.equal(typeof obj.owner, 'object');
-      assert.equal(typeof obj.owner.id, 'string');
-      assert.equal(typeof obj.owner.displayName, 'string');
-    }
-
-    it('should list only 1 object', function* () {
-      var result = yield this.store.list({
-        'max-keys': 1
-      });
-      assert.equal(result.objects.length, 1);
-      result.objects.map(checkObjectProperties);
-      assert.equal(typeof result.nextMarker, 'string');
-      assert(result.isTruncated);
-      assert.equal(result.prefixes, null);
-    });
-
-    it('should list top 3 objects', function* () {
-      var result = yield this.store.list({
-        'max-keys': 3
-      });
-      assert.equal(result.objects.length, 3);
-      result.objects.map(checkObjectProperties);
-      assert.equal(typeof result.nextMarker, 'string');
-      assert(result.isTruncated);
-      assert.equal(result.prefixes, null);
-
-      // next 2
-      var result2 = yield this.store.list({
-        'max-keys': 2,
-        marker: result.nextMarker
-      });
-      assert.equal(result2.objects.length, 2);
-      result.objects.map(checkObjectProperties);
-      assert.equal(typeof result2.nextMarker, 'string');
-      assert(result2.isTruncated);
-      assert.equal(result2.prefixes, null);
-    });
-
-    it('should list with prefix', function* () {
-      var result = yield this.store.list({
-        prefix: this.listPrefix + 'fun/movie/',
-      });
-      assert.equal(result.objects.length, 2);
-      result.objects.map(checkObjectProperties);
-      assert.equal(result.nextMarker, null);
-      assert(!result.isTruncated);
-      assert.equal(result.prefixes, null);
-
-      var result = yield this.store.list({
-        prefix: this.listPrefix + 'fun/movie',
-      });
-      assert.equal(result.objects.length, 2);
-      result.objects.map(checkObjectProperties);
-      assert.equal(result.nextMarker, null);
-      assert(!result.isTruncated);
-      assert.equal(result.prefixes, null);
-    });
-
-    it('should list current dir files only', function* () {
-      var result = yield this.store.list({
-        prefix: this.listPrefix,
-        delimiter: '/'
-      });
-      assert.equal(result.objects.length, 1);
-      result.objects.map(checkObjectProperties);
-      assert.equal(result.nextMarker, null);
-      assert(!result.isTruncated);
-      assert.deepEqual(result.prefixes, [this.listPrefix + 'fun/']);
-
-      var result = yield this.store.list({
-        prefix: this.listPrefix + 'fun/',
-        delimiter: '/'
-      });
-      assert.equal(result.objects.length, 1);
-      result.objects.map(checkObjectProperties);
-      assert.equal(result.nextMarker, null);
-      assert(!result.isTruncated);
-      assert.deepEqual(result.prefixes, [this.listPrefix + 'fun/movie/']);
-
-      var result = yield this.store.list({
-        prefix: this.listPrefix + 'fun/movie/',
-        delimiter: '/'
-      });
-      assert.equal(result.objects.length, 2);
-      result.objects.map(checkObjectProperties);
-      assert.equal(result.nextMarker, null);
-      assert(!result.isTruncated);
-      assert.equal(result.prefixes, null);
-    });
-  });
-});
+  }
+}


### PR DESCRIPTION
1. 干掉了带下划线的类方法，让 prototype 更干净清爽；
2. 添加 自定义 host 的支持：
原来只能通过 ￼http://oss-cn-hangzhou.aliyuncs.com/bucket-example/oss-demo.pdf 操作 object，现在可支持 ￼http://bucket-example.oss-cn-hangzhou.aliyuncs.com/oss-demo.pdf 操作。
即支持绑定域名，对于图片服务非常重要（必须要绑定域名访问）。