### PR TITLE
Fix ip endpoint

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -5,6 +5,7 @@
 require('babel-polyfill');
 
 var OSS = require('.');
+OSS.Buffer = require('buffer').Buffer;
 OSS.co = require('co');
 OSS.urllib = require('urllib');
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -341,7 +341,7 @@ proto._getReqUrl = function (params) {
   var ep = {};
   copy(this.options.endpoint).to(ep);
 
-  var isIP = this._isIP(ep.host);
+  var isIP = this._isIP(ep.hostname);
   var isCname = this.options.cname;
   if (params.bucket && !isCname && !isIP) {
     ep.host = params.bucket + '.' + ep.host;

--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -44,11 +44,10 @@ proto.multipartUpload = function* (name, file, options) {
 
   var fileSize = yield this._getFileSize(file);
   if (fileSize < minPartSize) {
-    var data = {
-      stream: this._createStream(file, 0, fileSize),
-      size: fileSize
-    };
-    var ret = yield this.putData(name, data, options);
+    var stream = this._createStream(file, 0, fileSize);
+    options.contentLength = fileSize;
+
+    var ret = yield this.putStream(name, stream, options);
     if (options && options.progress) {
       yield options.progress(1);
     }

--- a/lib/object.js
+++ b/lib/object.js
@@ -31,32 +31,39 @@ var proto = exports;
  * Object operations
  */
 
+/**
+ * put an object from String(file path)/Buffer/ReadableStream
+ * @param {String} name the object key
+ * @param {Mixed} file String(file path)/Buffer/ReadableStream
+ * @param {Object} options
+ * @return {Object}
+ */
 proto.put = function* (name, file, options) {
-  if (is.readableStream(file)) {
-    return yield this.putStream(name, file, options);
-  }
+  var content;
 
   options = options || {};
-  if (is.string(file)) {
+  if (is.buffer(file)) {
+    content = file;
+  } else if (is.string(file)) {
     options.mime = options.mime || mime.lookup(path.extname(file));
+    var stream = fs.createReadStream(file);
+    options.contentLength = yield this._getFileSize(file);
+    return yield this.putStream(name, stream, options);
+  } else if (is.readableStream(file)) {
+    return yield this.putStream(name, file, options);
+  } else {
+    throw new TypeError('Must provide String/Buffer/ReadableStream for put.');
   }
 
-  var data = yield* this._getContent(file);
-  return yield this.putData(name, data, options);
-};
-
-proto.putData = function* (name, data, options) {
-  options = options || {};
   options.headers = options.headers || {};
   this._convertMetaToHeaders(options.meta, options.headers);
 
   var params = this._objectRequestParams('PUT', name, options);
   params.mime = options.mime;
-  params.stream = data.stream;
-  params.content = data.content;
+  params.content = content;
   params.successStatuses = [200];
 
-  var result = yield* this.request(params);
+  var result = yield this.request(params);
 
   return {
     name: name,
@@ -65,10 +72,22 @@ proto.putData = function* (name, data, options) {
   };
 };
 
+/**
+ * put an object from ReadableStream. If `options.contentLength` is
+ * not provided, chunked encoding is used.
+ * @param {String} name the object key
+ * @param {Readable} stream the ReadableStream
+ * @param {Object} options
+ * @return {Object}
+ */
 proto.putStream = function* (name, stream, options) {
   options = options || {};
   options.headers = options.headers || {};
-  options.headers['Transfer-Encoding'] = 'chunked';
+  if (options.contentLength) {
+    options.headers['Content-Length'] = options.contentLength;
+  } else {
+    options.headers['Transfer-Encoding'] = 'chunked';
+  }
   this._convertMetaToHeaders(options.meta, options.headers);
   var params = this._objectRequestParams('PUT', name, options);
 
@@ -76,7 +95,7 @@ proto.putStream = function* (name, stream, options) {
   params.stream = stream;
   params.successStatuses = [200];
 
-  var result = yield* this.request(params);
+  var result = yield this.request(params);
 
   return {
     name: name,
@@ -89,7 +108,7 @@ proto.head = function* (name, options) {
   var params = this._objectRequestParams('HEAD', name, options);
   params.successStatuses = [200, 304];
 
-  var result = yield* this.request(params);
+  var result = yield this.request(params);
 
   var data = {
     meta: null,
@@ -131,7 +150,7 @@ proto.get = function* (name, file, options) {
     params.writeStream = writeStream;
     params.successStatuses = [200, 206, 304];
 
-    result = yield* this.request(params);
+    result = yield this.request(params);
 
     if (needDestroy) {
       writeStream.destroy();
@@ -158,7 +177,7 @@ proto.getStream = function* (name, options) {
   params.customResponse = true;
   params.successStatuses = [200, 206, 304];
 
-  var result = yield* this.request(params);
+  var result = yield this.request(params);
 
   return {
     stream: result.res,
@@ -173,7 +192,7 @@ proto.delete = function* (name, options) {
   var params = this._objectRequestParams('DELETE', name, options);
   params.successStatuses = [204];
 
-  var result = yield* this.request(params);
+  var result = yield this.request(params);
 
   return {
     res: result.res
@@ -201,7 +220,7 @@ proto.deleteMulti = function* (names, options) {
   params.content = xml;
   params.xmlResponse = true;
   params.successStatuses = [200];
-  var result = yield* this.request(params);
+  var result = yield this.request(params);
 
   var r = result.data;
   var deleted = r && r.Deleted || null;
@@ -241,7 +260,7 @@ proto.copy = function* (name, sourceName, options) {
   params.xmlResponse = true;
   params.successStatuses = [200, 304];
 
-  var result = yield* this.request(params);
+  var result = yield this.request(params);
 
   var data = result.data;
   if (data) {
@@ -410,43 +429,6 @@ proto.signatureUrl = function (name, options) {
 
 proto._objectUrl = function (name) {
   return this._getReqUrl({bucket: this.options.bucket, object: name});
-};
-
-/**
- * get content from string(file path), buffer(file content), stream(file stream)
- * @param {Mix} file
- * @return {Buffer}
- *
- * @api private
- */
-
-proto._getContent = function* (file) {
-  if (is.buffer(file)) {
-    return {
-      content: file,
-      size: file.length,
-    };
-  }
-
-  var content = {
-    stream: null,
-    size: null
-  };
-
-  if (is.string(file)) {
-    content.size = yield* this._getFileSize(file);
-    file = fs.createReadStream(file);
-    eoe(file, function () {
-      destroy(file);
-    });
-  }
-
-  if (!is.readableStream(file)) {
-    throw new TypeError('upload file type error, support: localfile, Buffer and ReadStream');
-  }
-
-  content.stream = file;
-  return content;
 };
 
 /**

--- a/lib/object.js
+++ b/lib/object.js
@@ -313,6 +313,56 @@ proto.list = function* (query, options) {
   };
 };
 
+/*
+ * Set object's ACL
+ * @param {String} name the object key
+ * @param {String} acl the object ACL
+ * @param {Object} options
+ */
+proto.putACL = function* (name, acl, options) {
+  options = options || {};
+  options.subres = 'acl';
+  options.headers = options.headers || {};
+  options.headers['x-oss-object-acl'] = acl;
+  name = this._objectName(name);
+
+  var params = this._objectRequestParams('PUT', name, options);
+  params.successStatuses = [200];
+
+  var result = yield this.request(params);
+
+  return {
+    res: result.res
+  };
+};
+
+/*
+ * Get object's ACL
+ * @param {String} name the object key
+ * @param {Object} options
+ * @return {Object}
+ */
+proto.getACL = function* (name, options) {
+  options = options || {};
+  options.subres = 'acl';
+  name = this._objectName(name);
+
+  var params = this._objectRequestParams('GET', name, options);
+  params.successStatuses = [200];
+  params.xmlResponse = true;
+
+  var result = yield this.request(params);
+
+  return {
+    acl: result.data.AccessControlList.Grant,
+    owner: {
+      id: result.data.Owner.ID,
+      displayName: result.data.Owner.DisplayName,
+    },
+    res: result.res
+  };
+};
+
 proto.signatureUrl = function (name, options) {
   name = this._objectName(name);
   var params = {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -163,7 +163,7 @@ describe('test/client.test.js', function () {
     var store = oss({
       accessKeyId: 'foo',
       accessKeySecret: 'bar',
-      endpoint: '127.0.0.1'
+      endpoint: 'http://127.0.0.1:6000'
     });
 
     var params = {
@@ -171,7 +171,7 @@ describe('test/client.test.js', function () {
     };
 
     var url = store._getReqUrl(params);
-    assert.equal(url, 'http://127.0.0.1/gems/');
+    assert.equal(url, 'http://127.0.0.1:6000/gems/');
   });
 
   it('should create request url with bucket/object/subres', function() {
@@ -230,7 +230,7 @@ describe('test/client.test.js', function () {
     var store = oss({
       accessKeyId: 'foo',
       accessKeySecret: 'bar',
-      endpoint: '127.0.0.1'
+      endpoint: 'http://127.0.0.1:3000'
     });
 
     var params = {
@@ -239,6 +239,6 @@ describe('test/client.test.js', function () {
     };
 
     var url = store._getReqUrl(params);
-    assert.equal(url, 'http://127.0.0.1/gems/hello');
+    assert.equal(url, 'http://127.0.0.1:3000/gems/hello');
   });
 });

--- a/test/object.test.js
+++ b/test/object.test.js
@@ -1252,4 +1252,27 @@ describe('test/object.test.js', function () {
       assert.deepEqual(result.deleted, names);
     });
   });
+
+  describe.only('putACL(), getACL()', function () {
+    it('should put and get object ACL', function* () {
+      var name = prefix + 'object/acl';
+      var result = yield this.store.put(name, new Buffer('hello world'));
+      assert.equal(result.res.status, 200);
+
+      var result = yield this.store.getACL(name);
+      assert.equal(result.res.status, 200);
+      assert.equal(result.acl, 'default');
+
+      var result = yield this.store.putACL(name, 'public-read');
+      assert.equal(result.res.status, 200);
+
+      var result = yield this.store.getACL(name);
+      assert.equal(result.res.status, 200);
+      assert.equal(result.acl, 'public-read');
+
+      var result = yield this.store.get(name);
+      assert.equal(result.res.status, 200);
+      assert.deepEqual(result.content, new Buffer('hello world'));
+    });
+  });
 });

--- a/test/object.test.js
+++ b/test/object.test.js
@@ -24,6 +24,7 @@ var config = require('./config').oss;
 var stsConfig = require('./config').sts;
 var urllib = require('urllib');
 var copy = require('copy-to');
+var mm = require('mm');
 
 var tmpdir = path.join(__dirname, '.tmp');
 if (!fs.existsSync(tmpdir)) {
@@ -54,6 +55,8 @@ describe('test/object.test.js', function () {
   });
 
   describe('putStream()', function () {
+    afterEach(mm.restore);
+
     it('should add object with streaming way', function* () {
       var name = prefix + 'ali-sdk/oss/putStream-localfile.js';
       var object = yield this.store.putStream(name, fs.createReadStream(__filename));
@@ -67,6 +70,40 @@ describe('test/object.test.js', function () {
       var r = yield this.store.get(name);
       assert.equal(r.res.status, 200);
       assert.equal(r.content.toString(), fs.readFileSync(__filename, 'utf8'));
+    });
+
+    it('should use chunked encoding', function* () {
+      var name = prefix + 'ali-sdk/oss/chunked-encoding.js';
+      var headers;
+      var req = this.store.urllib.requestThunk;
+      mm(this.store.urllib, 'requestThunk', function (url, args) {
+        headers = args.headers;
+        return req(url, args);
+      });
+
+      var result = yield this.store.putStream(name, fs.createReadStream(__filename));
+
+      assert.equal(result.res.status, 200);
+      assert.equal(headers['Transfer-Encoding'], 'chunked');
+    });
+
+    it('should NOT use chunked encoding', function* () {
+      var name = prefix + 'ali-sdk/oss/no-chunked-encoding.js';
+      var headers;
+      var req = this.store.urllib.requestThunk;
+      mm(this.store.urllib, 'requestThunk', function (url, args) {
+        headers = args.headers;
+        return req(url, args);
+      });
+
+      var options = {
+        contentLength: fs.statSync(__filename).size
+      };
+      var result = yield this.store.putStream(
+        name, fs.createReadStream(__filename), options);
+
+      assert(!headers['Transfer-Encoding']);
+      assert.equal(result.res.status, 200);
     });
 
     it('should add image with streaming way', function* () {
@@ -139,16 +176,6 @@ describe('test/object.test.js', function () {
       assert.equal(typeof object.res.rt, 'number');
       assert.equal(typeof object.res.headers.etag, 'string');
       assert(object.name, name);
-    });
-
-    it.skip('should throw TypeError when upload stream without Content-Length', function* () {
-      yield utils.throws(function* () {
-        var name = prefix + 'ali-sdk/oss/put-readstream';
-        yield this.store.put(name, fs.createReadStream(__filename));
-      }.bind(this), function (err) {
-        assert.equal(err.name, 'TypeError');
-        assert.equal(err.message, 'streaming upload must given the `Content-Length` header');
-      });
     });
 
     it('should add object with meta', function* () {
@@ -751,9 +778,7 @@ describe('test/object.test.js', function () {
 
       this.name = 'sts/signature';
       this.content = 'Get signature url with STS token.';
-      var result = yield this.ossClient.putData(this.name, {
-        content: this.content
-      });
+      var result = yield this.ossClient.put(this.name, new Buffer(this.content));
       assert.equal(result.res.status, 200);
     });
 
@@ -1253,7 +1278,7 @@ describe('test/object.test.js', function () {
     });
   });
 
-  describe.only('putACL(), getACL()', function () {
+  describe('putACL(), getACL()', function () {
     it('should put and get object ACL', function* () {
       var name = prefix + 'object/acl';
       var result = yield this.store.put(name, new Buffer('hello world'));


### PR DESCRIPTION
现在:
- `put`接口可以支持String(file path)/Buffer/ReadableStream
- `putStream`接口可以支持'chunked'（默认）和非'chunked'（通过指定contentLength）

```js
var stream = fs.createReadStream(__filanem);
var size = fs.statSync(__filename).size;
yield store.putStream(name, stream, {contentLength: size});
```