### PR TITLE
Add a wrapper to return Promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -1905,6 +1905,44 @@ Will put to all clients.
 - `client.copy()`
 - `client.putMeta()`
 
+## Wrapper Usage
+
+We provide an async wrapper which can be used without `co`. All the
+methods are preserved, just in a async way:
+
+```js
+
+var OSS = require('ali-oss').Wrapper;
+var STS = OSS.STS;
+
+var client = new OSS({ /* same options */});
+
+client.put('hello', new Buffer('world')).then(function (val) {
+  console.log('result: %j', val);
+}).catch (function (err) {
+  console.log('error: %j', err);
+});
+
+client.get('helloxxxx').then(function (val) {
+  console.log('result: %j', val);
+}).catch (function (err) {
+  console.log('error: %j', err);
+});
+
+var url = client.signatureUrl('hello');
+console.log(url);
+
+var stsClient = new STS({ /* same options */});
+
+var role = 'role';
+
+stsClient.assumeRole(role).then(function (val) {
+  console.log('result: %j', val);
+}).catch (function (err) {
+  console.log('error: %j', err);
+});
+```
+
 ## Browser Usage
 
 You can use most of the functionalities of `ali-oss` in browser with

--- a/lib/client.js
+++ b/lib/client.js
@@ -115,6 +115,11 @@ Client.ClusterClient = require('./cluster')(Client);
 Client.STS = require('./sts');
 
 /**
+ * Aysnc wrapper
+ */
+Client.Wrapper = require('./wrapper');
+
+/**
  * get OSS signature
  * @param {String} stringToSign
  * @return {String} the signature

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -35,7 +35,7 @@ function wrap(obj, options) {
 
   props.concat(protoProps).forEach(function(key) {
     if (isGeneratorFunction(client[key])) {
-      this[key] = co.wrap(client[key]);
+      this[key] = co.wrap(client[key]).bind(client);
     } else {
       this[key] = client[key];
     }

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -43,9 +43,17 @@ function wrap(obj, options) {
 }
 
 function Client(options) {
+  if (!(this instanceof Client)) {
+    return new Client(options);
+  }
+
   wrap.call(this, OSS, options);
 }
 
 Client.STS = function STSClient(options) {
+  if (!(this instanceof STSClient)) {
+    return new STSClient(options);
+  }
+
   wrap.call(this, OSS.STS, options);
 }

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright(c) rockuw and other contributors.
+ * MIT Licensed
+ *
+ * Authors:
+ *   rockuw <rockuw@gmail.com>
+ */
+
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+var co = require('co');
+var OSS = require('..');
+
+module.exports = Client;
+
+function isGenerator(obj) {
+  return 'function' == typeof obj.next && 'function' == typeof obj.throw;
+}
+
+function wrap(obj, options) {
+  this.client = new obj(options);
+
+  var self = this;
+
+  Object.keys(self.client.__proto__).map(function (k) {
+    var fn = self.client[k];
+    if (typeof fn == 'function') {
+      self[k] = function () {
+        var r = fn.apply(self.client, arguments);
+        if (isGenerator(r)) {
+          return co.wrap(fn).apply(self.client, arguments);
+        }
+        return r;
+      };
+    } else {
+      self[k] = fn;
+    }
+  });
+}
+
+function Client(options) {
+  wrap.call(this, OSS, options);
+}
+
+Client.STS = function STSClient(options) {
+  wrap.call(this, OSS.STS, options);
+}

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -21,25 +21,25 @@ function isGenerator(obj) {
   return 'function' == typeof obj.next && 'function' == typeof obj.throw;
 }
 
+function isGeneratorFunction(obj) {
+  var constructor = obj.constructor;
+  if (!constructor) return false;
+  if ('GeneratorFunction' === constructor.name || 'GeneratorFunction' === constructor.displayName) return true;
+  return isGenerator(constructor.prototype);
+}
+
 function wrap(obj, options) {
-  this.client = new obj(options);
+  var client = new obj(options);
+  var props = Object.keys(client);
+  var protoProps = Object.keys(Object.getPrototypeOf(client));
 
-  var self = this;
-
-  Object.keys(self.client.__proto__).map(function (k) {
-    var fn = self.client[k];
-    if (typeof fn == 'function') {
-      self[k] = function () {
-        var r = fn.apply(self.client, arguments);
-        if (isGenerator(r)) {
-          return co.wrap(fn).apply(self.client, arguments);
-        }
-        return r;
-      };
+  props.concat(protoProps).forEach(function(key) {
+    if (isGeneratorFunction(client[key])) {
+      this[key] = co.wrap(client[key]);
     } else {
-      self[k] = fn;
+      this[key] = client[key];
     }
-  });
+  }, this);
 }
 
 function Client(options) {

--- a/test/multipart.test.js
+++ b/test/multipart.test.js
@@ -175,33 +175,8 @@ describe('test/multipart.test.js', function () {
   describe('multipartUpload()', function () {
     afterEach(mm.restore);
 
-    var createFile = function* (name, size) {
-      var tmpdir = '/tmp/.oss/';
-      if (!fs.existsSync(tmpdir)) {
-        fs.mkdirSync(tmpdir);
-      }
-
-      yield new Promise(function (resolve, reject) {
-        var rs = fs.createReadStream('/dev/urandom', {
-          start: 0,
-          end: size - 1
-        });
-        var ws = fs.createWriteStream(tmpdir + name);
-        rs.pipe(ws);
-        ws.on('finish', function (err, res) {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(res);
-          }
-        });
-      });
-
-      return tmpdir + name;
-    };
-
     it('should fallback to putStream when file size is smaller than 100KB', function* () {
-      var fileName = yield* createFile('multipart-fallback', 100 * 1024 - 1);
+      var fileName = yield utils.createTempFile('multipart-fallback', 100 * 1024 - 1);
 
       var putStreamCalled = false;
       mm(this.store, 'putStream', function* () {
@@ -244,7 +219,7 @@ describe('test/multipart.test.js', function () {
 
     it('should upload file using multipart upload', function* () {
       // create a file with 1M random data
-      var fileName = yield* createFile('multipart-upload-file', 1024 * 1024);
+      var fileName = yield utils.createTempFile('multipart-upload-file', 1024 * 1024);
 
       var name = prefix + 'multipart/upload-file';
       var progress = 0;
@@ -281,7 +256,7 @@ describe('test/multipart.test.js', function () {
       mm(global, 'FileReader', FileReader);
 
       // create a file with 1M random data
-      var fileName = yield* createFile('multipart-upload-webfile', 1024 * 1024);
+      var fileName = yield utils.createTempFile('multipart-upload-webfile', 1024 * 1024);
       var fileBuf = fs.readFileSync(fileName);
       var webFile = new File(fileName, fileBuf);
 
@@ -312,7 +287,7 @@ describe('test/multipart.test.js', function () {
       });
 
       // create a file with 1M random data
-      var fileName = yield* createFile('multipart-upload-file', 1024 * 1024);
+      var fileName = yield utils.createTempFile('multipart-upload-file', 1024 * 1024);
 
       var name = prefix + 'multipart/upload-file';
       var cptFile = '/tmp/.oss/cpt.json';

--- a/test/utils.js
+++ b/test/utils.js
@@ -13,6 +13,7 @@
  */
 
 var assert = require('assert');
+var fs = require('fs');
 
 exports.throws = function* (block, checkError) {
   try {
@@ -66,3 +67,28 @@ exports.prefix = process.platform + '-' + process.version + '/';
 if (process.execPath.indexOf('iojs') >= 0) {
   exports.prefix = 'iojs-' + exports.prefix;
 }
+
+exports.createTempFile = function* (name, size) {
+  var tmpdir = '/tmp/.oss/';
+  if (!fs.existsSync(tmpdir)) {
+    fs.mkdirSync(tmpdir);
+  }
+
+  yield new Promise(function (resolve, reject) {
+    var rs = fs.createReadStream('/dev/urandom', {
+      start: 0,
+      end: size - 1
+    });
+    var ws = fs.createWriteStream(tmpdir + name);
+    rs.pipe(ws);
+    ws.on('finish', function (err, res) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(res);
+      }
+    });
+  });
+
+  return tmpdir + name;
+};

--- a/test/wrapper.test.js
+++ b/test/wrapper.test.js
@@ -1,0 +1,125 @@
+/**
+ * Copyright(c) ali-sdk and other contributors.
+ * MIT Licensed
+ *
+ * Authors:
+ *   fengmk2 <m@fengmk2.com> (http://fengmk2.com)
+ */
+
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+var assert = require('assert');
+var config = require('./config').oss;
+var stsConfig = require('./config').sts;
+var OSS = require('../').Wrapper;
+var STS = OSS.STS;
+var utils = require('./utils');
+var fs = require('fs');
+var md5 = require('utility').md5;
+var urllib = require('urllib');
+
+describe('test/wrapper.test.js', function () {
+  var prefix = utils.prefix;
+
+  before(function* () {
+    this.store = new OSS(config);
+    this.bucket = 'ali-oss-test-object-bucket-' + prefix.replace(/[\/\.]/g, '-');
+    this.bucket = this.bucket.substring(0, this.bucket.length - 1);
+    this.region = config.region;
+
+    var SyncClient = require('..');
+    this.syncClient = new SyncClient(config);
+    yield this.syncClient.putBucket(this.bucket, this.region);
+    this.syncClient.useBucket(this.bucket, this.region);
+    this.store.useBucket(this.bucket, this.region);
+  });
+
+  after(function* () {
+    yield utils.cleanBucket(this.syncClient, this.bucket, this.region);
+  });
+
+  it('should work for bucket operations', function () {
+    var bucket = this.bucket;
+
+    return this.store.listBuckets({
+      prefix: bucket,
+      'max-keys': 1
+    }).then(function (val) {
+      assert.equal(val.res.status, 200);
+      assert.equal(Array.isArray(val.buckets), true);
+      assert.equal(val.buckets.length, 1);
+      assert.equal(val.buckets[0].name, bucket);
+    });
+  });
+
+  it('should work for object operations', function () {
+    var name = 'async-put-object';
+    var content = 'should work for object operations';
+
+    var store = this.store;
+    return store.put(name, new Buffer(content)).then(function (val) {
+      assert.equal(val.res.status, 200);
+      assert.equal(val.name, name);
+
+      return store.get(name).then(function (val) {
+        assert.equal(val.res.status, 200);
+        assert.equal(val.content.toString(), content);
+      });
+    });
+  });
+
+  it('should work for multipart operations', function* () {
+    var name = 'async-multipart-upload';
+    var fileName = yield utils.createTempFile(name, 1024 * 1024);
+
+    var store = this.store;
+    return store.multipartUpload(name, fileName).then(function (val) {
+      assert.equal(val.res.status, 200);
+
+      return store.get(name).then(function (val) {
+        assert.equal(val.res.status, 200);
+        var fileBuf = fs.readFileSync(fileName);
+        assert.equal(val.content.length, fileBuf.length);
+        // avoid comparing buffers directly for it may hang when generating diffs
+        assert.equal(md5(val.content), md5(fileBuf));
+      });
+    });
+  });
+
+  it('should work for signature url', function* () {
+    var name = 'object-sig-url';
+    var content = 'should work for signature url';
+
+    yield this.syncClient.put(name, new Buffer(content));
+
+    var url = this.store.signatureUrl(name);
+    var urlRes = yield urllib.request(url);
+    assert.equal(urlRes.data.toString(), content);
+  });
+
+  it('should work on error', function () {
+    var name = 'file-not-exist';
+
+    return this.store.get(name).then(function (val) {
+      assert(false);
+    }).catch(function (err) {
+      assert.equal(err.name, 'NoSuchKeyError');
+      assert.equal(err.status, 404);
+      assert.equal(typeof err.requestId, 'string');
+    });
+  });
+
+  it('should work for sts operations', function () {
+    var stsClient = new STS(stsConfig);
+    return stsClient.assumeRole(stsConfig.roleArn).then(function (val) {
+      assert.equal(val.res.status, 200);
+      assert.equal(typeof val.credentials.AccessKeyId, 'string');
+      assert.equal(typeof val.credentials.AccessKeySecret, 'string');
+      assert.equal(typeof val.credentials.SecurityToken, 'string');
+    });
+  });
+});

--- a/test/wrapper.test.js
+++ b/test/wrapper.test.js
@@ -26,7 +26,7 @@ describe('test/wrapper.test.js', function () {
   var prefix = utils.prefix;
 
   before(function* () {
-    this.store = new OSS(config);
+    this.store = OSS(config);
     this.bucket = 'ali-oss-test-object-bucket-' + prefix.replace(/[\/\.]/g, '-');
     this.bucket = this.bucket.substring(0, this.bucket.length - 1);
     this.region = config.region;


### PR DESCRIPTION
很多用户还是习惯用callback的方式，返回promise可以让用户不用`co`也能用起来：

```js
var OSS = require('ali-oss').Wrapper;

var client = new OSS({
  endpoint: 'http://oss-test.aliyun-inc.com/ ',
  accessKeyId: 'xxxx',
  accessKeySecret: 'yyyy',
  bucket: 'bucket'
});

client.put('hello', new Buffer('world')).then(function (val) {
  console.log('result: %j', val);
}).catch (function (err) {
  console.log('error: %j', err);
});
```