### PR TITLE
fix: add warning event for first check available when use read only account on cluster mode

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -142,7 +142,11 @@ module.exports = function (oss) {
       yield that._checkAvailable(true);
       that.ready(true);
     }).catch(function(err) {
-      that.emit('error', err);
+      if (err.status && err.status === 403 && err.code === 'AccessDenied') {
+        that.emit('warning', err);
+      } else {
+        that.emit('error', err);
+      }
     });
   };
 

--- a/test/cluster.test.js
+++ b/test/cluster.test.js
@@ -80,6 +80,19 @@ describe('test/cluster.test.js', function () {
       mm.error(this.store, '_checkAvailable', 'mock error');
       this.store._init();
     });
+
+    it('should throw warning when use read only account _init() _checkAvailable ', function(done) {
+      this.store.once('warning', function(err) {
+        err.status.should.equal(403);
+        err.code.should.equal('AccessDenied');
+        done();
+      });
+      mm.error(this.store, '_checkAvailable', 'AccessDenied', {
+        status: 403,
+        code: 'AccessDenied'
+      });
+      this.store._init();
+    });
   });
 
   describe('put()', function () {


### PR DESCRIPTION
Ignore put check status file faild error and just emit warning event when use read only account on cluster mode