### PR TITLE
feature: add options.ignoreStatusFile to skip put status check file

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -51,7 +51,8 @@ module.exports = function (oss) {
 
     const heartbeatInterval = options.heartbeatInterval || 10000;
     this._checkAvailableLock = false;
-    this._timerId = defer.setInterval(this._checkAvailable.bind(this), heartbeatInterval);
+    this._timerId = defer.setInterval(this._checkAvailable.bind(this, true), heartbeatInterval);
+    this._ignoreStatusFile = options.ignoreStatusFile || false;
     this._init();
   }
 
@@ -139,16 +140,16 @@ module.exports = function (oss) {
   proto._init = function() {
     const that = this;
     co(function*() {
-      yield that._checkAvailable(true);
+      yield that._checkAvailable(that._ignoreStatusFile);
       that.ready(true);
     }).catch(function(err) {
       that.emit('error', err);
     });
   };
 
-  proto._checkAvailable = function*(first) {
+  proto._checkAvailable = function*(ignoreStatusFile) {
     const name = '._ali-oss/check.status.' + currentIP + '.txt';
-    if (first) {
+    if (!ignoreStatusFile) {
       // only start will try to write the file
       yield this.put(name, new Buffer('check available started at ' + Date()));
     }

--- a/test/cluster.test.js
+++ b/test/cluster.test.js
@@ -80,6 +80,11 @@ describe('test/cluster.test.js', function () {
       mm.error(this.store, '_checkAvailable', 'mock error');
       this.store._init();
     });
+
+    it('should skip put status file when ignoreStatusFile is set', function* () {
+      mm.error(this.store, 'put', 'mock error');
+      yield this.store._checkAvailable(true);
+    });
   });
 
   describe('put()', function () {


### PR DESCRIPTION
add options.ignoreStatusFile to ignore put check status file on cluster mode for some reasons, eg: read only account.