### PR TITLE
Fix isGeneratorFunction and Date format problems in IE10

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -28,7 +28,7 @@ var is = require('is-type-of');
 var platform = require('platform');
 var utility = require('utility');
 var pkg = require('../package.json');
-require('date-format-lite');
+var dateFormat = require('dateformat');
 
 /**
  * Expose `Client`
@@ -216,7 +216,7 @@ proto.createRequest = function (params) {
   var userAgent = this._userAgent();
 
   var headers = {
-    'x-oss-date': new Date().format('DDD, DD MMM YYYY HH:mm:ss "GMT"', 0),
+    'x-oss-date': dateFormat(new Date(), 'UTC:ddd, dd mmm yyyy HH:MM:ss \'GMT\''),
     'x-oss-user-agent': userAgent,
     'User-Agent': userAgent
   };

--- a/lib/client.js
+++ b/lib/client.js
@@ -28,6 +28,7 @@ var is = require('is-type-of');
 var platform = require('platform');
 var utility = require('utility');
 var pkg = require('../package.json');
+require('date-format-lite');
 
 /**
  * Expose `Client`
@@ -215,9 +216,7 @@ proto.createRequest = function (params) {
   var userAgent = this._userAgent();
 
   var headers = {
-    // For compatibility with IE10
-    // Also MDN says `toGMTString()` is deprecated
-    'x-oss-date': new Date().toUTCString().replace('UTC', 'GMT'),
+    'x-oss-date': new Date().format('DDD, DD MMM YYYY HH:mm:ss "GMT"', 0),
     'x-oss-user-agent': userAgent,
     'User-Agent': userAgent
   };

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -18,14 +18,14 @@ var OSS = require('..');
 module.exports = Client;
 
 function isGenerator(obj) {
-  return 'function' == typeof obj.next && 'function' == typeof obj.throw;
+  return obj && 'function' == typeof obj.next && 'function' == typeof obj.throw;
 }
 
 function isGeneratorFunction(obj) {
   var constructor = obj.constructor;
   if (!constructor) return false;
   if ('GeneratorFunction' === constructor.name || 'GeneratorFunction' === constructor.displayName) return true;
-  return isGenerator(constructor.prototype);
+  return isGenerator(constructor.prototype) || isGenerator(obj.prototype);
 }
 
 function wrap(obj, options) {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "co": "~4.6.0",
     "co-defer": "~1.0.0",
     "copy-to": "~2.0.1",
-    "date-format-lite": "^0.8.0",
+    "dateformat": "^1.0.12",
     "debug": "~2.2.0",
     "destroy": "~1.0.4",
     "end-or-error": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "co": "~4.6.0",
     "co-defer": "~1.0.0",
     "copy-to": "~2.0.1",
+    "date-format-lite": "^0.8.0",
     "debug": "~2.2.0",
     "destroy": "~1.0.4",
     "end-or-error": "~1.0.1",


### PR DESCRIPTION
1. `return isGenerator(constructor.prototype)` 这句话似乎是不对的，要换成`return isGenerator(obj.prototype)`

![image](https://cloud.githubusercontent.com/assets/1209779/15774084/1df79870-29ad-11e6-8224-e3b51354486e.png)

2. IE10的`toUTCString()`的日期不是两位数

![image](https://cloud.githubusercontent.com/assets/1209779/15774102/39b6c09a-29ad-11e6-85d4-ccabe6942612.png)
