### PR TITLE
add callback support for upload signature

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -411,6 +411,10 @@ proto.signatureUrl = function (name, options) {
     query[key] = options.response[k];
     signList.push(key + '=' + options.response[k]);
   }
+  if(options.callback){
+    signList.push('callback=' + options.callback);
+  }
+
   if (this.options.stsToken) {
     query['security-token'] = this.options.stsToken;
     signList.push('security-token=' + this.options.stsToken);
@@ -433,8 +437,11 @@ proto.signatureUrl = function (name, options) {
   url.query = {
     OSSAccessKeyId: this.options.accessKeyId,
     Expires: expires,
-    Signature: signature
+    Signature: signature,
   };
+  if(options.callback){
+    url.query.callback = options.callback
+  }
   copy(query).to(url.query);
 
   return url.format();


### PR DESCRIPTION
add callback support for signatureUrl

support below:

const callback = {
      "callbackUrl": "http://xxxx.com/api/v0/ossCallback",
      "callbackBody": "bucket=${bucket}&object=${object}&etag=${etag}&size=${size}&mimeType=${mimeType}&height=${imageInfo.height}&width=${imageInfo.width}&format=${imageInfo.format}"
    }
  const buf = Buffer.from(JSON.stringify(callback));
var url = store.signatureUrl('ossdemo.png', {
  expires: 3600,
  method: 'PUT',
  callback: Buffer.from(buf).toString('base64')
});
