### PR TITLE
doc: param "file" of *get method is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -916,7 +916,7 @@ var object = this.store.head('ossdemo/head-meta');
 // will throw NoSuchKeyError
 ```
 
-### .get*(name, file[, options])
+### .get*(name[, file, options])
 
 Get an object from the bucket.
 


### PR DESCRIPTION
I got a surprise when write `yield get(somepath, null, options)`