### PR TITLE
:bug: fix bowser dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "beautify-benchmark": "^0.2.4",
     "benchmark": "^2.1.1",
     "bluebird": "^3.1.5",
-    "bowser": "^1.6.0",
     "browserify": "^13.0.1",
     "co-fs": "^1.2.0",
     "crypto-browserify": "^1.0.9",
@@ -67,6 +66,7 @@
   "dependencies": {
     "address": "^1.0.0",
     "agentkeepalive": "^2.1.1",
+    "bowser": "^1.6.0",
     "co": "^4.6.0",
     "co-defer": "^1.0.0",
     "co-gather": "^0.0.1",


### PR DESCRIPTION
main is **lib/client.js**, but it requires **bowser**, so **bowser** should be in **dependencies**