### PR TITLE
Fix Uncaught TypeError: Cannot read property 'length' of null 

### DIFF
--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -336,7 +336,7 @@ util.inherits(WebFileReadStream, Readable);
 WebFileReadStream.prototype.readFileAndPush = function readFileAndPush(size) {
   if (this.fileBuffer){
     var pushRet = true;
-    while (this.start < this.fileBuffer.length && pushRet) {
+    while (pushRet && this.start < this.fileBuffer.length) {
       var start = this.start;
       var end = start + size;
       end = end > this.fileBuffer.length ? this.fileBuffer.length : end;


### PR DESCRIPTION
Fix Uncaught TypeError: Cannot read property 'length' of null when using multipartUpload to upload small size file(few KBs).

I'm using below sample code from doc,

```
<body>
    <input type="file" id="file" />
    <script type="text/javascript">
    var client = new OSS.Wrapper({
        bucket: 'bucket', 
        region: 'oss-cn-beijing',
        secure: true,
        timeout: 20,
        accessKeyId: "STS.",
        accessKeySecret: "",
        stsToken: ""
    });
    document.getElementById('file').addEventListener('change', function (e) {
        var file = e.target.files[0];
        var storeAs = "363ab1f2-f178-4a4c-b205-90006c7c4002/oyGD7w2xSx-kf4qK1E51s-mkWXCA/58746b670cf248354105bfc2/upload-file";
        console.log(file.name + ' => ' + storeAs);
        client.multipartUpload(storeAs, file).then(function (result) {
            console.log(result);
        }).catch(function (err) {
            console.log(err);
        });
    });
</script>
</body>
```
