### PR TITLE
use content-type from specified options headers in multipart upload

### DIFF
--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -91,7 +91,7 @@ proto._resumeMultipart = function* _resumeMultipart(checkpoint, options) {
       size: pi.end - pi.start
     };
 
-    var result = yield self._uploadPart(name, uploadId, partNo, data);
+    var result = yield self._uploadPart(name, uploadId, partNo, data, options);
     doneParts.push({
       number: partNo,
       etag: result.res.headers.etag
@@ -226,7 +226,8 @@ proto._initMultipartUpload = function* _initMultipartUpload(name, options) {
 proto._uploadPart = function* _uploadPart(name, uploadId, partNo, data, options) {
   options = options || {};
   options.headers = {
-    'Content-Length': data.size
+    'Content-Length': data.size,
+    'Content-Type': options.headers !== undefined ? options.headers['Content-Type']: undefined
   };
 
   options.subres = {


### PR DESCRIPTION
right now, a different header (in fact, only content-length is specified) is used on PUT calls in multipart upload and the original content-type header is ignored. However, if content-type is not specified, we'll get permission denied from OSS. This commit is to fix in multipart upload of file more than several kbs, the POST call is successful, but ensuing PUT calls fails with 403.