### PR TITLE
fix: the multipartUpload return value has same structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1130,6 +1130,7 @@ parameters:
 - name {String} object name store on OSS
 - [options] {Object} optional parameters
   - [timeout] {Number} the operation timeout
+  - [process] {String} image process params, will send with `x-oss-process`
   - [headers] {Object} extra headers
     - 'If-Modified-Since' object modified after this time will return 200 and object meta,
         otherwise return 304 not modified
@@ -1535,6 +1536,17 @@ parameters:
     - 'Content-Encoding' object content encoding for download, e.g.: `Content-Encoding: gzip`
     - 'Expires' expires time (milliseconds) for download, e.g.: `Expires: 3600000`
     - **NOTE**: Some headers are [disabled in browser][disabled-browser-headers]
+
+Success will return:
+
+- res {Object} response info, including
+  - status {Number} response status
+  - headers {Object} response headers
+  - size {Number} response size
+  - rt {Number} request total use time (ms)
+- bucket {String} bucket name
+- name name {String} object name store on OSS
+- etag {String} object etag contains ", e.g.: "5B3C1A2E053D763E1B002CC607C5A0FE"
 
 example:
 

--- a/lib/browser/multipart.js
+++ b/lib/browser/multipart.js
@@ -39,17 +39,21 @@ proto.multipartUpload = function* multipartUpload(name, file, options) {
     var stream = this._createStream(file, 0, fileSize);
     options.contentLength = fileSize;
 
-    var ret = yield this.putStream(name, stream, options);
+    var result = yield this.putStream(name, stream, options);
     if (options && options.progress) {
       yield options.progress(1);
     }
 
-    return {
-      res: ret.res,
+    var ret =  {
+      res: result.res,
       bucket: this.options.bucket,
       name: name,
-      etag: ret.res.headers.etag
+      etag: result.res.headers.etag
     };
+    if (options.headers && options.headers['x-oss-callback']) {
+      ret.data = JSON.parse(result.data.toString());
+    }
+    return ret;
   }
 
   if (options.partSize && options.partSize < minPartSize) {

--- a/lib/browser/multipart.js
+++ b/lib/browser/multipart.js
@@ -44,7 +44,12 @@ proto.multipartUpload = function* multipartUpload(name, file, options) {
       yield options.progress(1);
     }
 
-    return ret;
+    return {
+      res: ret.res,
+      bucket: this.options.bucket,
+      name: name,
+      etag: ret.res.headers.etag
+    };
   }
 
   if (options.partSize && options.partSize < minPartSize) {

--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -39,17 +39,21 @@ proto.multipartUpload = function* multipartUpload(name, file, options) {
     var stream = this._createStream(file, 0, fileSize);
     options.contentLength = fileSize;
 
-    var ret = yield this.putStream(name, stream, options);
+    var result = yield this.putStream(name, stream, options);
     if (options && options.progress) {
       yield options.progress(1);
     }
-    
-    return {
-      res: ret.res,
+
+    var ret =  {
+      res: result.res,
       bucket: this.options.bucket,
       name: name,
-      etag: ret.res.headers.etag
+      etag: result.res.headers.etag
     };
+    if (options.headers && options.headers['x-oss-callback']) {
+      ret.data = JSON.parse(result.data.toString());
+    }
+    return ret;
   }
 
   if (options.partSize && options.partSize < minPartSize) {

--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -43,8 +43,13 @@ proto.multipartUpload = function* multipartUpload(name, file, options) {
     if (options && options.progress) {
       yield options.progress(1);
     }
-
-    return ret;
+    
+    return {
+      res: ret.res,
+      bucket: this.options.bucket,
+      name: name,
+      etag: ret.res.headers.etag
+    };
   }
 
   if (options.partSize && options.partSize < minPartSize) {

--- a/test/browser.tests.js
+++ b/test/browser.tests.js
@@ -684,7 +684,7 @@ describe('browser', function () {
         var progress = 0;
         var putStreamSpy = sinon.spy(this.store, 'putStream');
         var uploadPartSpy = sinon.spy(this.store, '_uploadPart');
-        yield this.store.multipartUpload(name, file, {
+        var result = yield this.store.multipartUpload(name, file, {
             progress: function () {
               return function (done) {
                 progress++;
@@ -695,6 +695,10 @@ describe('browser', function () {
         );
         assert.equal(putStreamSpy.callCount, 1);
         assert.equal(uploadPartSpy.callCount, 0);
+        assert.equal(typeof result.name, 'string');
+        assert.equal(typeof result.bucket, 'string');
+        assert.equal(typeof result.etag, 'string');
+
         assert.equal(progress, 1);
         this.store.putStream.restore();
         this.store._uploadPart.restore();

--- a/test/multipart.test.js
+++ b/test/multipart.test.js
@@ -182,8 +182,8 @@ describe('test/multipart.test.js', function () {
       assert.equal(uploadPartSpy.callCount, 0);
       assert.equal(progress, 1);
 
-      assert(result.bucket);
-      assert(result.etag);
+      assert.equal(typeof result.bucket, 'string');
+      assert.equal(typeof result.etag, 'string');
 
       this.store.putStream.restore();
       this.store._uploadPart.restore();

--- a/test/multipart.test.js
+++ b/test/multipart.test.js
@@ -166,26 +166,27 @@ describe('test/multipart.test.js', function () {
 
     it('should fallback to putStream when file size is smaller than 100KB', function* () {
       var fileName = yield utils.createTempFile('multipart-fallback', 100 * 1024 - 1);
-
-      var putStreamCalled = false;
-      mm(this.store, 'putStream', function* () {
-        putStreamCalled = true;
-      });
-      var uploadPartCalled = false;
-      mm(this.store, '_uploadPart', function* () {
-        uploadPartCalled = true;
-      });
-
       var name = prefix + 'multipart/fallback';
       var progress = 0;
-      yield this.store.multipartUpload(name, fileName, {
+      
+      var putStreamSpy = sinon.spy(this.store, 'putStream');
+      var uploadPartSpy = sinon.spy(this.store, '_uploadPart');
+      
+      var result = yield this.store.multipartUpload(name, fileName, {
         progress: function () {
           progress++;
         }
       });
-      assert(putStreamCalled);
-      assert(!uploadPartCalled);
+      assert.equal(result.res.status, 200);
+      assert.equal(putStreamSpy.callCount, 1);
+      assert.equal(uploadPartSpy.callCount, 0);
       assert.equal(progress, 1);
+
+      assert(result.bucket);
+      assert(result.etag);
+
+      this.store.putStream.restore();
+      this.store._uploadPart.restore();
     });
 
     it('should use default partSize when not specified', function* () {


### PR DESCRIPTION
fix: the multipartUpload return value has same object

when file size is small then minPartSize, the multipartUpload methods also return ‘bucket’、‘name’、‘etag’

Closes #282