### PR TITLE
MOD: include dist directory for TypeScript usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/client.js",
   "files": [
     "lib",
-    "shims"
+    "shims",
+    "dist"
   ],
   "browser": {
     "lib/client.js": "./lib/browser.js",


### PR DESCRIPTION
Use the client from `import 'ali-oss'` will throw `TypeError: crypto.createHmac is not a
function` because the crypto shim is not loaded in this case. And the package in npm repository did not publish a packaged version for browser usage. So I think the `dist` directory should be published.