### PR TITLE
Turn on the secure option in https pages

### DIFF
--- a/lib/browser/client.js
+++ b/lib/browser/client.js
@@ -58,10 +58,12 @@ Client.initOptions = function initOptions(options) {
     throw new Error('require accessKeyId, accessKeySecret');
   }
 
+  var isHttpsPage = document && document.location && document.location.protocol === 'https:'
+
   var opts = {
     region: 'oss-cn-hangzhou',
     internal: false,
-    secure: false,
+    secure: isHttpsPage,
     timeout: 60000, // 60s
     bucket: null,
     endpoint: null,


### PR DESCRIPTION
再也不用担心https页面不知道有个secure选项啦   （demo里面没写这个选项）