### PR TITLE
反序列化错误

### DIFF
--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -50,7 +50,7 @@ proto.multipartUpload = function* multipartUpload(name, file, options) {
       name: name,
       etag: result.res.headers.etag
     };
-    if (options.headers && options.headers['x-oss-callback']) {
+    if (!(options.headers && options.headers['x-oss-callback'])) {
       ret.data = JSON.parse(result.data.toString());
     }
     return ret;


### PR DESCRIPTION
在24行putstream中已经对resutl.data进行反序列化，所以54行会对一个object类型进行tostring，导致JSON.parse报错。