### PR TITLE
remove redundant comma

### DIFF
--- a/lib/managed_upload.js
+++ b/lib/managed_upload.js
@@ -259,7 +259,7 @@ proto._getPartSize = function _getPartSize(fileSize, partSize) {
 
   return Math.max(
     Math.ceil(fileSize / maxNumParts),
-    partSize,
+    partSize
   );
 };
 

--- a/lib/sts.js
+++ b/lib/sts.js
@@ -99,7 +99,7 @@ proto.assumeRole = function* assumeRole(role, policy, expiration, session, optio
   const result = yield this.urllib.request(reqUrl, reqParams);
   debug(
     'response %s %s, got %s, headers: %j',
-    reqParams.method, reqUrl, result.status, result.headers,
+    reqParams.method, reqUrl, result.status, result.headers
   );
 
   if (Math.floor(result.status / 100) !== 2) {


### PR DESCRIPTION
causing error in Node 6.x:
/Users/liux/git/web/node_modules/ali-oss/lib/sts.js:103
  );
  ^
SyntaxError: Unexpected token )
    at createScript (vm.js:56:10)
    at Object.runInThisContext (vm.js:97:10)
    at Module._compile (module.js:542:28)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/liux/git/web/node_modules/ali-oss/lib/client.js:162:14)