### PR TITLE
 get接口支持添加自定义参数

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -540,6 +540,7 @@ proto._objectRequestParams = function (method, name, options) {
     subres: options && options.subres,
     timeout: options && options.timeout,
     ctx: options && options.ctx,
+    query: options && options.query
   };
 
   if (options.headers) {


### PR DESCRIPTION
如果bucket配置了回源，没有自定义参数无法对其他平台的私有bucket进行回源。这里需要传递，可以这样使用 store.get(key, {query: {e: 'aaaa', token: 'cccc'}})。用于满足 internal: true 下，客户端->oss->其他平台的获取方式。