### PR TITLE
fix: add requestId for unknown error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -464,7 +464,8 @@ proto.requestError = function* requestError(result) {
         err.status = 412;
         err.code = 'PreconditionFailed';
       } else {
-        err = new Error(`Unknow error, status: ${result.status}`);
+        // expose requireId for debug unknown error
+        err = new Error(`Unknow error, status: ${result.status} (requestId: ${result.headers['x-oss-request-id']})`);
         err.name = 'UnknowError';
         err.status = result.status;
       }


### PR DESCRIPTION
由于 unknown error, status 200 偶现, 且时机不确定, 因此希望在 ali-oss 里加上 requestId 信息, 以方便排查问题.

原 ISSUE: https://github.com/ali-sdk/ali-oss/issues/378