### PR TITLE
fix: Cannot find module './browser/client' while useing browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dist"
   ],
   "browser": {
-    "lib/client.js": "./dist/aliyun-oss-sdk.js",
+    "lib/client.js": "./lib/browser.js",
     "mime": "./shims/mime.js",
     "urllib": "./shims/xhr.js",
     "utility": "./shims/utility.js",


### PR DESCRIPTION
解决issue：[https://github.com/ali-sdk/ali-oss/issues/562](url)
sdk引入ali-oss，使用browserify打包时报错