### PR TITLE
使用自定义参数，覆盖默认headers，比如 x-oss-date

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -227,7 +227,7 @@ proto.createRequest = function createRequest(params) {
     headers['x-oss-security-token'] = this.options.stsToken;
   }
 
-  copy(params.headers).to(headers);
+  Object.assign(headers, params.headers);
 
   if (!getHeader(headers, 'Content-Type')) {
     if (params.mime === mime.default_type) {


### PR DESCRIPTION
使用自定义参数，覆盖默认headers，比如 x-oss-date, 详见 [issues: 573](https://github.com/ali-sdk/ali-oss/issues/573)