### PR TITLE
修复在IE10下，分片上传图片为空白

### DIFF
--- a/lib/browser/managed-upload.js
+++ b/lib/browser/managed-upload.js
@@ -180,7 +180,11 @@ proto._resumeMultipart = async function _resumeMultipart(checkpoint, options) {
         throw this._makeCancelEvent();
       }
       /* eslint no-await-in-loop: [0] */
-      await uploadPartJob(this, todo[i]);
+      const result = await uploadPartJob(this, todo[i])
+      // at ie 10 function completeMultipartUpload() combine complete xml
+      if (result) {
+        internalDoneParts.push(result);
+      }
     }
   } else {
     // // upload in parallel


### PR DESCRIPTION
在IE10下
completeMultipartUpload请求参数的xml有问题
导致文件上传无法读取