### PR TITLE
修改所有new Buffer()写法为node推荐的方式，避免运行时出现方法过时警告

### DIFF
--- a/README.md
+++ b/README.md
@@ -987,7 +987,7 @@ store.put('ossdemo/demo.txt', filepath).then((result) => {
 - Add an object through content buffer
 
 ```js
-store.put('ossdemo/buffer', new Buffer('foo content')).then((result) => {
+store.put('ossdemo/buffer', Buffer.from('foo content')).then((result) => {
   console.log(result);
 });
 
@@ -1141,10 +1141,10 @@ object:
 example:
 
 ```js
-let object = await store.apend('ossdemo/buffer', new Buffer('foo'));
+let object = await store.apend('ossdemo/buffer',  Buffer.from('foo'));
 
 // append content to the existing object
-object = await store.apend('ossdemo/buffer', new Buffer('bar'), {
+object = await store.apend('ossdemo/buffer', Buffer.from('bar'), {
   position: object.nextAppendPosition,
 });
 ```
@@ -1214,7 +1214,7 @@ example:
 - Head an exists object and get user meta
 
 ```js
-await this.store.put('ossdemo/head-meta', new Buffer('foo'), {
+await this.store.put('ossdemo/head-meta', Buffer.from('foo'), {
   meta: {
     uid: 1,
     path: 'foo/demo.txt'

--- a/dist/aliyun-oss-sdk.js
+++ b/dist/aliyun-oss-sdk.js
@@ -268,7 +268,7 @@ proto.createRequest = function createRequest(params) {
   }
 
   if (params.content) {
-    headers['Content-Md5'] = crypto.createHash('md5').update(new Buffer(params.content, 'utf8')).digest('base64');
+    headers['Content-Md5'] = crypto.createHash('md5').update(Buffer.from(params.content, 'utf8')).digest('base64');
     if (!headers['Content-Length']) {
       headers['Content-Length'] = params.content.length;
     }
@@ -1156,7 +1156,7 @@ WebFileReadStream.prototype._read = function _read(size) {
 
   var that = this;
   this.reader.onload = function onload(e) {
-    that.fileBuffer = new Buffer(new Uint8Array(e.target.result));
+    that.fileBuffer = Buffer.from(new Uint8Array(e.target.result));
     that.file = null;
     that.readFileAndPush(size);
   };
@@ -2103,7 +2103,7 @@ exports.encodeCallback = function encodeCallback(reqParams, options) {
       if (options.callback.contentType) {
         json.callbackBodyType = options.callback.contentType;
       }
-      var callback = new Buffer((0, _stringify2.default)(json)).toString('base64');
+      var callback = Buffer.from((0, _stringify2.default)(json)).toString('base64');
       reqParams.headers['x-oss-callback'] = callback;
 
       if (options.callback.customValue) {
@@ -2111,7 +2111,7 @@ exports.encodeCallback = function encodeCallback(reqParams, options) {
         (0, _keys2.default)(options.callback.customValue).forEach(function (key) {
           callbackVar['x:' + key] = options.callback.customValue[key];
         });
-        reqParams.headers['x-oss-callback-var'] = new Buffer((0, _stringify2.default)(callbackVar)).toString('base64');
+        reqParams.headers['x-oss-callback-var'] = Buffer.from((0, _stringify2.default)(callbackVar)).toString('base64');
       }
     }
   }
@@ -2812,7 +2812,7 @@ exports.buildCanonicalString = function canonicalString(method, resourcePath, re
  */
 exports.computeSignature = function computeSignature(accessKeySecret, canonicalString) {
   var signature = crypto.createHmac('sha1', accessKeySecret);
-  return signature.update(new Buffer(canonicalString, 'utf8')).digest('base64');
+  return signature.update(Buffer.from(canonicalString, 'utf8')).digest('base64');
 };
 
 /**
@@ -2876,14 +2876,14 @@ exports._signatureForURL = function _signatureForURL(accessKeySecret, options, r
     if (options.callback.contentType) {
       json.callbackBodyType = options.callback.contentType;
     }
-    subResource.callback = new Buffer((0, _stringify2.default)(json)).toString('base64');
+    subResource.callback = Buffer.from((0, _stringify2.default)(json)).toString('base64');
 
     if (options.callback.customValue) {
       var callbackVar = {};
       (0, _keys2.default)(options.callback.customValue).forEach(function (key) {
         callbackVar['x:' + key] = options.callback.customValue[key];
       });
-      subResource['callback-var'] = new Buffer((0, _stringify2.default)(callbackVar)).toString('base64');
+      subResource['callback-var'] = Buffer.from((0, _stringify2.default)(callbackVar)).toString('base64');
     }
   }
 
@@ -3992,7 +3992,7 @@ var StringDecoder = exports.StringDecoder = function(encoding) {
 
   // Enough space to store all bytes of a single character. UTF-8 needs 4
   // bytes, but CESU-8 may require up to 6 (3 bytes per surrogate).
-  this.charBuffer = new Buffer(6);
+  this.charBuffer = Buffer.alloc(6);
   // Number of bytes received for the current incomplete multi-byte character.
   this.charReceived = 0;
   // Number of bytes expected for the current incomplete multi-byte character.
@@ -4224,7 +4224,7 @@ function createBuffer (that, length) {
   } else {
     // Fallback: Return an object instance of the Buffer class
     if (that === null) {
-      that = new Buffer(length)
+      that = Buffer.alloc(length)
     }
     that.length = length
   }
@@ -4244,7 +4244,7 @@ function createBuffer (that, length) {
 
 function Buffer (arg, encodingOrOffset, length) {
   if (!Buffer.TYPED_ARRAY_SUPPORT && !(this instanceof Buffer)) {
-    return new Buffer(arg, encodingOrOffset, length)
+    return Buffer.from(arg, encodingOrOffset, length)
   }
 
   // Common case.
@@ -5227,7 +5227,7 @@ Buffer.prototype.slice = function slice (start, end) {
     newBuf.__proto__ = Buffer.prototype
   } else {
     var sliceLen = end - start
-    newBuf = new Buffer(sliceLen, undefined)
+    newBuf =  Buffer.alloc(sliceLen, undefined)
     for (var i = 0; i < sliceLen; ++i) {
       newBuf[i] = this[i + start]
     }
@@ -5776,7 +5776,7 @@ Buffer.prototype.fill = function fill (val, start, end, encoding) {
   } else {
     var bytes = Buffer.isBuffer(val)
       ? val
-      : utf8ToBytes(new Buffer(val, encoding).toString())
+      : utf8ToBytes(Buffer.from(val, encoding).toString())
     var len = bytes.length
     for (i = 0; i < end - start; ++i) {
       this[i + start] = bytes[i % len]
@@ -8679,7 +8679,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   /**
    * Get ISO-8601 numeric representation of the day of the week
    * 1 (for Monday) through 7 (for Sunday)
-   * 
+   *
    * @param  {Object} `date`
    * @return {Number}
    */
@@ -17802,7 +17802,7 @@ var ClientRequest = module.exports = function (opts) {
 	self._opts = opts;
 	self._body = [];
 	self._headers = {};
-	if (opts.auth) self.setHeader('Authorization', 'Basic ' + new Buffer(opts.auth).toString('base64'));
+	if (opts.auth) self.setHeader('Authorization', 'Basic ' + Buffer.from(opts.auth).toString('base64'));
 	(0, _keys2.default)(opts.headers).forEach(function (name) {
 		self.setHeader(name, opts.headers[name]);
 	});
@@ -18111,7 +18111,7 @@ var IncomingMessage = exports.IncomingMessage = function (xhr, response, mode, f
 					self.push(null);
 					return;
 				}
-				self.push(new Buffer(result.value));
+				self.push(Buffer.from(result.value));
 				read();
 			}).catch(function (err) {
 				global.clearTimeout(fetchTimer);
@@ -18136,7 +18136,7 @@ var IncomingMessage = exports.IncomingMessage = function (xhr, response, mode, f
 					return new _promise2.default(function (resolve, reject) {
 						if (self._destroyed) {
 							reject();
-						} else if (self.push(new Buffer(chunk))) {
+						} else if (self.push(Buffer.from(chunk))) {
 							resolve();
 						} else {
 							self._resumeFetch = resolve;
@@ -18231,10 +18231,10 @@ IncomingMessage.prototype._onXHRProgress = function () {
 				response = new global.VBArray(xhr.responseBody).toArray();
 			} catch (e) {}
 			if (response !== null) {
-				self.push(new Buffer(response));
+				self.push(Buffer.from(response));
 				break;
 			}
-		// Falls through in IE8	
+		// Falls through in IE8
 		case 'text':
 			try {
 				// This will fail when readyState = 3 in IE9. Switch mode and wait for readyState = 4
@@ -18246,7 +18246,7 @@ IncomingMessage.prototype._onXHRProgress = function () {
 			if (response.length > self._pos) {
 				var newData = response.substr(self._pos);
 				if (self._charset === 'x-user-defined') {
-					var buffer = new Buffer(newData.length);
+					var buffer = Buffer.alloc(newData.length);
 					for (var i = 0; i < newData.length; i++) {
 						buffer[i] = newData.charCodeAt(i) & 0xff;
 					}self.push(buffer);
@@ -18259,13 +18259,13 @@ IncomingMessage.prototype._onXHRProgress = function () {
 		case 'arraybuffer':
 			if (xhr.readyState !== rStates.DONE || !xhr.response) break;
 			response = xhr.response;
-			self.push(new Buffer(new Uint8Array(response)));
+			self.push(Buffer.from(new Uint8Array(response)));
 			break;
 		case 'moz-chunked-arraybuffer':
 			// take whole
 			response = xhr.response;
 			if (xhr.readyState !== rStates.LOADING || !response) break;
-			self.push(new Buffer(new Uint8Array(response)));
+			self.push(Buffer.from(new Uint8Array(response)));
 			break;
 		case 'ms-stream':
 			response = xhr.response;
@@ -18273,7 +18273,7 @@ IncomingMessage.prototype._onXHRProgress = function () {
 			var reader = new global.MSStreamReader();
 			reader.onprogress = function () {
 				if (reader.result.byteLength > self._pos) {
-					self.push(new Buffer(new Uint8Array(reader.result.slice(self._pos))));
+					self.push(Buffer.from(new Uint8Array(reader.result.slice(self._pos))));
 					self._pos = reader.result.byteLength;
 				}
 			};
@@ -23660,12 +23660,12 @@ var algorithms = {
 };
 
 var blocksize = 64;
-var zeroBuffer = new Buffer(blocksize);
+var zeroBuffer = Buffer.alloc(blocksize);
 zeroBuffer.fill(0);
 
 function hmac(fn, key, data) {
-  if (!Buffer.isBuffer(key)) key = new Buffer(key);
-  if (!Buffer.isBuffer(data)) data = new Buffer(data);
+  if (!Buffer.isBuffer(key)) key = Buffer.from(key);
+  if (!Buffer.isBuffer(data)) data = Buffer.from(data);
 
   if (key.length > blocksize) {
     key = fn(key);
@@ -23673,8 +23673,8 @@ function hmac(fn, key, data) {
     key = Buffer.concat([key, zeroBuffer], blocksize);
   }
 
-  var ipad = new Buffer(blocksize),
-      opad = new Buffer(blocksize);
+  var ipad = Buffer.alloc(blocksize),
+      opad = Buffer.alloc(blocksize);
   for (var i = 0; i < blocksize; i++) {
     ipad[i] = key[i] ^ 0x36;
     opad[i] = key[i] ^ 0x5C;
@@ -23692,7 +23692,7 @@ function hash(alg, key) {
   if (!fn) error('algorithm:', alg, 'is not yet supported');
   return {
     update: function update(data) {
-      if (!Buffer.isBuffer(data)) data = new Buffer(data);
+      if (!Buffer.isBuffer(data)) data = Buffer.from(data);
 
       bufs.push(data);
       length += data.length;
@@ -23737,7 +23737,7 @@ each(['createCredentials', 'createCipher', 'createCipheriv', 'createDecipher', '
 
 var Buffer = require('buffer').Buffer;
 var intSize = 4;
-var zeroBuffer = new Buffer(intSize);zeroBuffer.fill(0);
+var zeroBuffer = Buffer.alloc(intSize);zeroBuffer.fill(0);
 var chrsz = 8;
 
 function toArray(buf, bigEndian) {
@@ -23755,7 +23755,7 @@ function toArray(buf, bigEndian) {
 }
 
 function toBuffer(arr, size, bigEndian) {
-  var buf = new Buffer(size);
+  var buf = Buffer.alloc(size);
   var fn = bigEndian ? buf.writeInt32BE : buf.writeInt32LE;
   for (var i = 0; i < arr.length; i++) {
     fn.call(buf, arr[i], i * 4, true);
@@ -23764,7 +23764,7 @@ function toBuffer(arr, size, bigEndian) {
 }
 
 function hash(buf, fn, hashSize, bigEndian) {
-  if (!Buffer.isBuffer(buf)) buf = new Buffer(buf);
+  if (!Buffer.isBuffer(buf)) buf = Buffer.from(buf);
   var arr = fn(toArray(buf, bigEndian), buf.length * chrsz);
   return toBuffer(arr, hashSize, bigEndian);
 }

--- a/example/src/main.js
+++ b/example/src/main.js
@@ -184,7 +184,7 @@ const uploadContent = function uploadContent(client) {
   const key = document.getElementById('object-key-content').value.trim() || 'object';
   console.log(`content => ${key}`);
 
-  return client.put(key, new Buffer(content)).then(res => listFiles(client));
+  return client.put(key, Buffer.from(content)).then(res => listFiles(client));
 };
 
 const uploadBlob = function (client) {
@@ -198,7 +198,7 @@ const uploadBlob = function (client) {
 const putBlob = function (client) {
   const content = document.getElementById('put-blob').value.trim();
   const key = document.getElementById('object-key-put-blob').value.trim() || 'blob';
-  const md5String = crypto.createHash('md5').update(new Buffer(content, 'utf8')).digest('base64');
+  const md5String = crypto.createHash('md5').update(Buffer.from(content, 'utf8')).digest('base64');
   const options = {
     expires: 1800,
     method: 'PUT',

--- a/lib/browser/client.js
+++ b/lib/browser/client.js
@@ -239,7 +239,7 @@ proto.createRequest = function createRequest(params) {
   if (params.content) {
     headers['Content-Md5'] = crypto
       .createHash('md5')
-      .update(new Buffer(params.content, 'utf8'))
+      .update(Buffer.from(params.content, 'utf8'))
       .digest('base64');
     if (!headers['Content-Length']) {
       headers['Content-Length'] = params.content.length;

--- a/lib/browser/managed-upload.js
+++ b/lib/browser/managed-upload.js
@@ -284,7 +284,7 @@ WebFileReadStream.prototype._read = function _read(size) {
 
   const that = this;
   this.reader.onload = function onload(e) {
-    that.fileBuffer = new Buffer(new Uint8Array(e.target.result));
+    that.fileBuffer = Buffer.from(new Uint8Array(e.target.result));
     that.file = null;
     that.readFileAndPush(size);
   };

--- a/lib/client.js
+++ b/lib/client.js
@@ -249,7 +249,7 @@ proto.createRequest = function createRequest(params) {
   if (params.content) {
     headers['Content-Md5'] = crypto
       .createHash('md5')
-      .update(new Buffer(params.content, 'utf8'))
+      .update(Buffer.from(params.content, 'utf8'))
       .digest('base64');
     if (!headers['Content-Length']) {
       headers['Content-Length'] = params.content.length;

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -130,7 +130,7 @@ module.exports = function (OssClient) {
     const name = `._ali-oss/check.status.${currentIP}.txt`;
     if (!ignoreStatusFile) {
       // only start will try to write the file
-      await this.put(name, new Buffer(`check available started at ${Date()}`));
+      await this.put(name, Buffer.from(`check available started at ${Date()}`));
     }
 
     if (this._checkAvailableLock) {

--- a/lib/common/callback.js
+++ b/lib/common/callback.js
@@ -14,7 +14,7 @@ exports.encodeCallback = function encodeCallback(reqParams, options) {
       if (options.callback.contentType) {
         json.callbackBodyType = options.callback.contentType;
       }
-      const callback = new Buffer(JSON.stringify(json)).toString('base64');
+      const callback = Buffer.from(JSON.stringify(json)).toString('base64');
       reqParams.headers['x-oss-callback'] = callback;
 
       if (options.callback.customValue) {
@@ -22,7 +22,7 @@ exports.encodeCallback = function encodeCallback(reqParams, options) {
         Object.keys(options.callback.customValue).forEach((key) => {
           callbackVar[`x:${key}`] = options.callback.customValue[key];
         });
-        reqParams.headers['x-oss-callback-var'] = new Buffer(JSON.stringify(callbackVar)).toString('base64');
+        reqParams.headers['x-oss-callback-var'] = Buffer.from(JSON.stringify(callbackVar)).toString('base64');
       }
     }
   }

--- a/lib/common/signUtils.js
+++ b/lib/common/signUtils.js
@@ -84,7 +84,7 @@ exports.buildCanonicalString = function canonicalString(method, resourcePath, re
  */
 exports.computeSignature = function computeSignature(accessKeySecret, canonicalString) {
   const signature = crypto.createHmac('sha1', accessKeySecret);
-  return signature.update(new Buffer(canonicalString, 'utf8')).digest('base64');
+  return signature.update(Buffer.from(canonicalString, 'utf8')).digest('base64');
 };
 
 /**
@@ -148,14 +148,14 @@ exports._signatureForURL = function _signatureForURL(accessKeySecret, options, r
     if (options.callback.contentType) {
       json.callbackBodyType = options.callback.contentType;
     }
-    subResource.callback = new Buffer(JSON.stringify(json)).toString('base64');
+    subResource.callback = Buffer.from(JSON.stringify(json)).toString('base64');
 
     if (options.callback.customValue) {
       const callbackVar = {};
       Object.keys(options.callback.customValue).forEach((key) => {
         callbackVar[`x:${key}`] = options.callback.customValue[key];
       });
-      subResource['callback-var'] = new Buffer(JSON.stringify(callbackVar)).toString('base64');
+      subResource['callback-var'] = Buffer.from(JSON.stringify(callbackVar)).toString('base64');
     }
   }
 

--- a/lib/managed-upload.js
+++ b/lib/managed-upload.js
@@ -240,7 +240,7 @@ WebFileReadStream.prototype._read = function _read(size) {
 
   const that = this;
   this.reader.onload = function (e) {
-    that.fileBuffer = new Buffer(new Uint8Array(e.target.result));
+    that.fileBuffer = Buffer.from(new Uint8Array(e.target.result));
     that.file = null;
     that.readFileAndPush(size);
   };

--- a/shims/crypto/crypto.js
+++ b/shims/crypto/crypto.js
@@ -11,12 +11,12 @@ var algorithms = {
 };
 
 var blocksize = 64;
-var zeroBuffer = new Buffer(blocksize);
+var zeroBuffer = Buffer.alloc(blocksize);
 zeroBuffer.fill(0);
 
 function hmac(fn, key, data) {
-  if(!Buffer.isBuffer(key)) key = new Buffer(key);
-  if(!Buffer.isBuffer(data)) data = new Buffer(data);
+  if(!Buffer.isBuffer(key)) key = Buffer.from(key);
+  if(!Buffer.isBuffer(data)) data = Buffer.from(data);
 
   if(key.length > blocksize) {
     key = fn(key)
@@ -24,7 +24,7 @@ function hmac(fn, key, data) {
     key = Buffer.concat([key, zeroBuffer], blocksize)
   }
 
-  var ipad = new Buffer(blocksize), opad = new Buffer(blocksize);
+  var ipad = Buffer.alloc(blocksize), opad = Buffer.alloc(blocksize);
   for(var i = 0; i < blocksize; i++) {
     ipad[i] = key[i] ^ 0x36
     opad[i] = key[i] ^ 0x5C
@@ -42,7 +42,7 @@ function hash(alg, key) {
   if(!fn) error('algorithm:', alg, 'is not yet supported');
   return {
     update: function (data) {
-      if(!Buffer.isBuffer(data)) data = new Buffer(data);
+      if(!Buffer.isBuffer(data)) data = Buffer.from(data);
 
       bufs.push(data);
       length += data.length;

--- a/shims/crypto/helpers.js
+++ b/shims/crypto/helpers.js
@@ -1,6 +1,6 @@
 var Buffer = require('buffer').Buffer;
 var intSize = 4;
-var zeroBuffer = new Buffer(intSize); zeroBuffer.fill(0);
+var zeroBuffer = Buffer.alloc(intSize); zeroBuffer.fill(0);
 var chrsz = 8;
 
 function toArray(buf, bigEndian) {
@@ -18,7 +18,7 @@ function toArray(buf, bigEndian) {
 }
 
 function toBuffer(arr, size, bigEndian) {
-  var buf = new Buffer(size);
+  var buf = Buffer.alloc(size);
   var fn = bigEndian ? buf.writeInt32BE : buf.writeInt32LE;
   for (var i = 0; i < arr.length; i++) {
     fn.call(buf, arr[i], i * 4, true);
@@ -27,7 +27,7 @@ function toBuffer(arr, size, bigEndian) {
 }
 
 function hash(buf, fn, hashSize, bigEndian) {
-  if (!Buffer.isBuffer(buf)) buf = new Buffer(buf);
+  if (!Buffer.isBuffer(buf)) buf = Buffer.from(buf);
   var arr = fn(toArray(buf, bigEndian), buf.length * chrsz);
   return toBuffer(arr, hashSize, bigEndian);
 }

--- a/test/browser/browser.test.js
+++ b/test/browser/browser.test.js
@@ -380,12 +380,12 @@ describe('browser', () => {
     before(async () => {
       client = oss(ossConfig);
       listPrefix = `${prefix}ali-sdk/list/`;
-      await client.put(`${listPrefix}oss.jpg`, new Buffer('oss.jpg'));
-      await client.put(`${listPrefix}fun/test.jpg`, new Buffer('fun/test.jpg'));
-      await client.put(`${listPrefix}fun/movie/001.avi`, new Buffer('fun/movie/001.avi'));
-      await client.put(`${listPrefix}fun/movie/007.avi`, new Buffer('fun/movie/007.avi'));
-      await client.put(`${listPrefix}other/movie/007.avi`, new Buffer('other/movie/007.avi'));
-      await client.put(`${listPrefix}other/movie/008.avi`, new Buffer('other/movie/008.avi'));
+      await client.put(`${listPrefix}oss.jpg`, Buffer.from('oss.jpg'));
+      await client.put(`${listPrefix}fun/test.jpg`, Buffer.from('fun/test.jpg'));
+      await client.put(`${listPrefix}fun/movie/001.avi`, Buffer.from('fun/movie/001.avi'));
+      await client.put(`${listPrefix}fun/movie/007.avi`, Buffer.from('fun/movie/007.avi'));
+      await client.put(`${listPrefix}other/movie/007.avi`, Buffer.from('other/movie/007.avi'));
+      await client.put(`${listPrefix}other/movie/008.avi`, Buffer.from('other/movie/008.avi'));
     });
 
     function checkObjectProperties(obj) {
@@ -493,7 +493,7 @@ describe('browser', () => {
     });
     it('GETs and PUTs objects to a bucket', async () => {
       const name = `${prefix}put/test`;
-      const body = new Buffer('body');
+      const body = Buffer.from('body');
       const resultPut = await store.put(name, body);
       assert.equal(resultPut.res.status, 200);
       const resultGet = await store.get(name);
@@ -534,7 +534,7 @@ describe('browser', () => {
     before(async () => {
       store = oss(ossConfig);
       name = `${prefix}ali-sdk/oss/signatureUrl.js`;
-      let object = await store.put(name, new Buffer('signatureUrl'), {
+      let object = await store.put(name, Buffer.from('signatureUrl'), {
         meta: {
           uid: 1,
           pid: '123',
@@ -547,7 +547,7 @@ describe('browser', () => {
       // this.headers = object.res.headers;
 
       needEscapeName = `${prefix}ali-sdk/oss/%3get+meta-signatureUrl.js`;
-      object = await store.put(needEscapeName, new Buffer('%3get+meta-signatureUrl'), {
+      object = await store.put(needEscapeName, Buffer.from('%3get+meta-signatureUrl'), {
         meta: {
           uid: 1,
           pid: '123',
@@ -586,7 +586,7 @@ describe('browser', () => {
       const putString = 'Hello World';
       const contentMd5 = crypto1
         .createHash('md5')
-        .update(new Buffer(putString, 'utf8'))
+        .update(Buffer.from(putString, 'utf8'))
         .digest('base64');
       console.log(contentMd5);
       const url = store.signatureUrl(name, {
@@ -1119,7 +1119,7 @@ describe('browser', () => {
     });
     it('When the client\'s date is skew, the request will calibration time and retry', async () => {
       const name = `${prefix}put/skew_date`;
-      const body = new Buffer('body');
+      const body = Buffer.from('body');
       const requestSpy = sinon.spy(store, 'request');
       const requestErrorSpy = sinon.spy(store, 'requestError');
 

--- a/test/node/object.test.js
+++ b/test/node/object.test.js
@@ -1,4 +1,3 @@
-
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
@@ -128,7 +127,8 @@ describe('test/object.test.js', () => {
     it('should add very big file: 4mb with streaming way', async () => {
       const name = `${prefix}ali-sdk/oss/bigfile-4mb.bin`;
       const bigfile = path.join(__dirname, '.tmp', 'bigfile-4mb.bin');
-      fs.writeFileSync(bigfile, Buffer.alloc(4 * 1024 * 1024).fill('a\n'));
+      fs.writeFileSync(bigfile, Buffer.alloc(4 * 1024 * 1024)
+        .fill('a\n'));
       const object = await store.putStream(name, fs.createReadStream(bigfile));
       assert.equal(typeof object.res.headers['x-oss-request-id'], 'string');
       assert.equal(typeof object.res.rt, 'number');
@@ -193,7 +193,7 @@ describe('test/object.test.js', () => {
 
     it('should add object with content buffer', async () => {
       const name = `${prefix}ali-sdk/oss/put-buffer`;
-      const object = await store.put(`/${name}`, new Buffer('foo content'));
+      const object = await store.put(`/${name}`, Buffer.from('foo content'));
       assert.equal(typeof object.res.headers['x-oss-request-id'], 'string');
       assert.equal(typeof object.res.rt, 'number');
       assert(object.name, name);
@@ -602,11 +602,13 @@ describe('test/object.test.js', () => {
     it('should get object content buffer', async () => {
       let result = await store.get(name);
       assert(Buffer.isBuffer(result.content), 'content should be Buffer');
-      assert(result.content.toString().indexOf('ali-sdk/oss/get-meta.js') > 0);
+      assert(result.content.toString()
+        .indexOf('ali-sdk/oss/get-meta.js') > 0);
 
       result = await store.get(name, null);
       assert(Buffer.isBuffer(result.content), 'content should be Buffer');
-      assert(result.content.toString().indexOf('ali-sdk/oss/get-meta.js') > 0);
+      assert(result.content.toString()
+        .indexOf('ali-sdk/oss/get-meta.js') > 0);
     });
 
     it('should get object content buffer with image process', async () => {
@@ -627,7 +629,10 @@ describe('test/object.test.js', () => {
       // when 'subres.x-oss-process' coexists with 'process'.
       result = await store.get(
         imageName,
-        { process: 'image/resize,w_200', subres: { 'x-oss-process': 'image/resize,w_100' } },
+        {
+          process: 'image/resize,w_200',
+          subres: { 'x-oss-process': 'image/resize,w_100' }
+        }
       );
       assert.equal(result.res.status, 200);
       assert(Buffer.isBuffer(result.content), 'content should be Buffer');
@@ -655,7 +660,8 @@ describe('test/object.test.js', () => {
           }
         });
         assert(Buffer.isBuffer(result.content), 'content should be Buffer');
-        assert(result.content.toString().indexOf('ali-sdk/oss/get-meta.js') > 0);
+        assert(result.content.toString()
+          .indexOf('ali-sdk/oss/get-meta.js') > 0);
         assert.equal(result.res.status, 200);
       });
 
@@ -713,7 +719,8 @@ describe('test/object.test.js', () => {
         });
         assert.equal(result.res.status, 200);
         assert(Buffer.isBuffer(result.content), 'content should be Buffer');
-        assert(result.content.toString().indexOf('ali-sdk/oss/get-meta.js') > 0);
+        assert(result.content.toString()
+          .indexOf('ali-sdk/oss/get-meta.js') > 0);
       });
 
       it('should 200 when If-Unmodified-Since > object modified time', async () => {
@@ -727,7 +734,8 @@ describe('test/object.test.js', () => {
         });
         assert.equal(result.res.status, 200);
         assert(Buffer.isBuffer(result.content), 'content should be Buffer');
-        assert(result.content.toString().indexOf('ali-sdk/oss/get-meta.js') > 0);
+        assert(result.content.toString()
+          .indexOf('ali-sdk/oss/get-meta.js') > 0);
       });
     });
 
@@ -778,7 +786,7 @@ describe('test/object.test.js', () => {
 
     describe('Range header', () => {
       it('should work with Range header and get top 10 bytes content', async () => {
-        const content = new Buffer('aaaaaaaaaabbbbbbbbbb');
+        const content = Buffer.from('aaaaaaaaaabbbbbbbbbb');
         await store.put('range-header-test', content);
         const result = await store.get('range-header-test', {
           headers: {
@@ -842,7 +850,10 @@ describe('test/object.test.js', () => {
         mime: 'image/png'
       });
 
-      const signUrl = store.signatureUrl(imageName, { expires: 3600, process: 'image/resize,w_200' });
+      const signUrl = store.signatureUrl(imageName, {
+        expires: 3600,
+        process: 'image/resize,w_200'
+      });
       const processedKeyword = 'x-oss-process=image%2Fresize%2Cw_200';
       assert.equal(signUrl.match(processedKeyword), processedKeyword);
       const urlRes = await urllib.request(signUrl);
@@ -853,7 +864,9 @@ describe('test/object.test.js', () => {
 
     it('should signature url for PUT', async () => {
       const putString = 'Hello World';
-      const contentMd5 = crypto.createHash('md5').update(new Buffer(putString, 'utf8')).digest('base64');
+      const contentMd5 = crypto.createHash('md5')
+        .update(Buffer.from(putString, 'utf8'))
+        .digest('base64');
       const url = store.signatureUrl(name, {
         method: 'PUT',
         'Content-Type': 'text/plain; charset=UTF-8',
@@ -863,7 +876,11 @@ describe('test/object.test.js', () => {
         'Content-Type': 'text/plain; charset=UTF-8',
         'Content-MD5': contentMd5
       };
-      const res = await urllib.request(url, { method: 'PUT', data: putString, headers });
+      const res = await urllib.request(url, {
+        method: 'PUT',
+        data: putString,
+        headers
+      });
       assert.equal(res.status, 200);
       const headRes = await store.head(name);
       assert.equal(headRes.status, 200);
@@ -901,7 +918,8 @@ describe('test/object.test.js', () => {
 
     it('should signature url with custom host ok', () => {
       const conf = {};
-      copy(config).to(conf);
+      copy(config)
+        .to(conf);
       conf.endpoint = 'www.aliyun.com';
       conf.cname = true;
       const tempStore = oss(conf);
@@ -959,7 +977,10 @@ describe('test/object.test.js', () => {
       assert(isEqual);
       result = await store.getStream(
         imageName,
-        { process: 'image/resize,w_200', subres: { 'x-oss-process': 'image/resize,w_100' } },
+        {
+          process: 'image/resize,w_200',
+          subres: { 'x-oss-process': 'image/resize,w_100' }
+        }
       );
       assert.equal(result.res.status, 200);
       isEqual = await streamEqual(result.stream, fs.createReadStream(processedImagePath));
@@ -1034,8 +1055,10 @@ describe('test/object.test.js', () => {
     });
 
     it('should delete 2 exists and 2 not exists objs', async () => {
-      const result = await store.deleteMulti(names.slice(0, 2).concat(['not-exist1', 'not-exist2']));
-      assert.deepEqual(result.deleted, names.slice(0, 2).concat(['not-exist1', 'not-exist2']));
+      const result = await store.deleteMulti(names.slice(0, 2)
+        .concat(['not-exist1', 'not-exist2']));
+      assert.deepEqual(result.deleted, names.slice(0, 2)
+        .concat(['not-exist1', 'not-exist2']));
       assert.equal(result.res.status, 200);
     });
 
@@ -1365,12 +1388,12 @@ describe('test/object.test.js', () => {
     let listPrefix;
     before(async () => {
       listPrefix = `${prefix}ali-sdk/list/`;
-      await store.put(`${listPrefix}oss.jpg`, new Buffer('oss.jpg'));
-      await store.put(`${listPrefix}fun/test.jpg`, new Buffer('fun/test.jpg'));
-      await store.put(`${listPrefix}fun/movie/001.avi`, new Buffer('fun/movie/001.avi'));
-      await store.put(`${listPrefix}fun/movie/007.avi`, new Buffer('fun/movie/007.avi'));
-      await store.put(`${listPrefix}other/movie/007.avi`, new Buffer('other/movie/007.avi'));
-      await store.put(`${listPrefix}other/movie/008.avi`, new Buffer('other/movie/008.avi'));
+      await store.put(`${listPrefix}oss.jpg`, Buffer.from('oss.jpg'));
+      await store.put(`${listPrefix}fun/test.jpg`, Buffer.from('fun/test.jpg'));
+      await store.put(`${listPrefix}fun/movie/001.avi`, Buffer.from('fun/movie/001.avi'));
+      await store.put(`${listPrefix}fun/movie/007.avi`, Buffer.from('fun/movie/007.avi'));
+      await store.put(`${listPrefix}other/movie/007.avi`, Buffer.from('other/movie/007.avi'));
+      await store.put(`${listPrefix}other/movie/008.avi`, Buffer.from('other/movie/008.avi'));
     });
 
     function checkObjectProperties(obj) {
@@ -1488,7 +1511,7 @@ describe('test/object.test.js', () => {
       /* eslint no-await-in-loop: [0] */
       for (const k in keys) {
         const key = prefixz + keys[k];
-        let result = await store.put(key, new Buffer(''));
+        let result = await store.put(key, Buffer.from(''));
         assert.equal(result.res.status, 200);
 
         result = await store.list({
@@ -1512,7 +1535,7 @@ describe('test/object.test.js', () => {
   describe('putACL(), getACL()', () => {
     it('should put and get object ACL', async () => {
       const name = `${prefix}object/acl`;
-      let result = await store.put(name, new Buffer('hello world'));
+      let result = await store.put(name, Buffer.from('hello world'));
       assert.equal(result.res.status, 200);
 
       result = await store.getACL(name);
@@ -1528,7 +1551,7 @@ describe('test/object.test.js', () => {
 
       result = await store.get(name);
       assert.equal(result.res.status, 200);
-      assert.deepEqual(result.content, new Buffer('hello world'));
+      assert.deepEqual(result.content, Buffer.from('hello world'));
     });
   });
 
@@ -1539,7 +1562,7 @@ describe('test/object.test.js', () => {
     });
 
     it('should apend object with content buffer', async () => {
-      let object = await store.append(name, new Buffer('foo'));
+      let object = await store.append(name, Buffer.from('foo'));
       assert(object.res.status === 200);
       assert(object.nextAppendPosition === '3');
       assert(object.res.headers['x-oss-next-append-position'] === '3');
@@ -1548,7 +1571,7 @@ describe('test/object.test.js', () => {
       assert(res.data.toString() === 'foo');
       assert(res.headers['x-oss-next-append-position'] === '3');
 
-      object = await store.append(name, new Buffer('bar'), {
+      object = await store.append(name, Buffer.from('bar'), {
         position: 3
       });
       assert(object.res.status === 200);
@@ -1581,10 +1604,10 @@ describe('test/object.test.js', () => {
     });
 
     it('should error when positio not match', async () => {
-      await store.append(name, new Buffer('foo'));
+      await store.append(name, Buffer.from('foo'));
 
       try {
-        await store.append(name, new Buffer('foo'));
+        await store.append(name, Buffer.from('foo'));
         throw new Error('should not run');
       } catch (err) {
         assert(err.message === 'Position is not equal to file length');
@@ -1593,14 +1616,14 @@ describe('test/object.test.js', () => {
     });
 
     it('should use nextAppendPosition to append next', async () => {
-      let object = await store.append(name, new Buffer('foo'));
+      let object = await store.append(name, Buffer.from('foo'));
       assert(object.nextAppendPosition === '3');
 
-      object = await store.append(name, new Buffer('bar'), {
+      object = await store.append(name, Buffer.from('bar'), {
         position: object.nextAppendPosition
       });
 
-      object = await store.append(name, new Buffer('baz'), {
+      object = await store.append(name, Buffer.from('baz'), {
         position: object.nextAppendPosition
       });
 

--- a/test/node/utils.js
+++ b/test/node/utils.js
@@ -119,5 +119,5 @@ exports.encodeCallback = function (cb) {
     callbackBodyType: cb.contentType || 'application/x-www-form-urlencoded'
   };
 
-  return new Buffer(JSON.stringify(json)).toString('base64');
+  return Buffer.from(JSON.stringify(json)).toString('base64');
 };


### PR DESCRIPTION
修改所有new Buffer()写法为node推荐的方式，避免运行时出现方法过时警告
如：
`(node:28956) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.`