### PR TITLE
feat: remove unused proto._statFile

### DIFF
--- a/lib/browser/managed-upload.js
+++ b/lib/browser/managed-upload.js
@@ -219,12 +219,9 @@ proto._getFileSize = async function _getFileSize(file) {
     return file.length;
   } else if (is.blob(file) || is.file(file)) {
     return file.size;
-  } if (is.string(file)) {
-    const stat = await this._statFile(file);
-    return stat.size;
   }
 
-  throw new Error('_getFileSize requires Buffer/File/String.');
+  throw new Error('_getFileSize requires Buffer/File/Blob.');
 };
 
 /*
@@ -300,7 +297,7 @@ proto._createStream = function _createStream(file, start, end) {
   //   });
   // }
 
-  throw new Error('_createStream requires File/String.');
+  throw new Error('_createStream requires File/Blob.');
 };
 
 proto._getPartSize = function _getPartSize(fileSize, partSize) {

--- a/lib/browser/object.js
+++ b/lib/browser/object.js
@@ -509,18 +509,6 @@ proto._objectName = function _objectName(name) {
   return name.replace(/^\/+/, '');
 };
 
-proto._statFile = function _statFile(filepath) {
-  return new Promise((resolve, reject) => {
-    fs.stat(filepath, (err, stats) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(stats);
-      }
-    });
-  });
-};
-
 proto._convertMetaToHeaders = function _convertMetaToHeaders(meta, headers) {
   if (!meta) {
     return;


### PR DESCRIPTION
浏览器环境下 file 不可能是 string，所以 _statFile() 方法时无用的。