### PR TITLE
feat: browser端,将 is-type-of 包处理为本地 shim

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "useTabs": false,
+  "printWidth": 80,
+  "bracketSpacing": true,
+  "arrowParens": "avoid"
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "utility": "./shims/utility.js",
     "crypto": "./shims/crypto/crypto.js",
     "fs": false,
-    "child_process": false
+    "child_process": false,
+    "is-type-of": "./shims/is-type-of.js"
   },
   "scripts": {
     "build-change-log": "standard-version",

--- a/shims/is-type-of.js
+++ b/shims/is-type-of.js
@@ -1,0 +1,22 @@
+const { Stream } = require('stream');
+const isArray = require('../lib/common/utils/isArray');
+
+module.exports.string = function isString(obj) {
+  return typeof obj === 'string';
+};
+
+module.exports.array = isArray;
+
+module.exports.buffer = Buffer.isBuffer;
+
+function isStream(obj) {
+  return obj instanceof Stream;
+}
+
+module.exports.writableStream = function isWritableStream(obj) {
+  return (
+    isStream(obj) &&
+    typeof obj._write === 'function' &&
+    typeof obj._writableState === 'object'
+  );
+};


### PR DESCRIPTION
`aliyun-oss-sdk.min.js` 体积从 `451K` 减小到 `397K`