### PR TITLE
feat: multipartUpload support Node.JS Buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2623,7 +2623,7 @@ or give tips in your business code;
 parameters:
 
 - name {String} object name
-- file {String|File(only support Browser)|Blob(only support Browser)} file path or HTML5 Web File or web Blob
+- file {String|File(only support Browser)|Blob(only support Browser)|Buffer} file path or HTML5 Web File or web Blob or content buffer
 - [options] {Object} optional args
   - [parallel] {Number} the number of parts to be uploaded in parallel
   - [partSize] {Number} the suggested size for each part

--- a/lib/browser/managed-upload.js
+++ b/lib/browser/managed-upload.js
@@ -18,7 +18,7 @@ const proto = exports;
 /**
  * Upload a file to OSS using multipart uploads
  * @param {String} name
- * @param {String|File} file
+ * @param {String|File|Buffer} file
  * @param {Object} options
  *        {Object} options.callback The callback parameter is composed of a JSON string encoded in Base64
  *        {String} options.callback.url the OSS sends a callback request to this URL
@@ -45,6 +45,8 @@ proto.multipartUpload = async function multipartUpload(name, file, options) {
       options.mime = mime.getType(path.extname(file.name));
     } else if (isBlob(file)) {
       options.mime = file.type;
+    } else if (is.buffer(file)) {
+      options.mime = '';
     } else {
       options.mime = mime.getType(path.extname(file));
     }
@@ -283,9 +285,18 @@ WebFileReadStream.prototype._read = function _read(size) {
 proto._createStream = function _createStream(file, start, end) {
   if (isBlob(file) || isFile(file)) {
     return new WebFileReadStream(file.slice(start, end));
+  } else if (is.buffer(file)) {
+    // we can't use Readable.from() since it is only support in Node v10
+    const iterable = file.subarray(start, end);
+    return new Readable({
+      read() {
+        this.push(iterable);
+        this.push(null);
+      }
+    });
   }
 
-  throw new Error('_createStream requires File/Blob.');
+  throw new Error('_createStream requires Buffer/File/Blob.');
 };
 
 proto._getPartSize = function _getPartSize(fileSize, partSize) {

--- a/lib/managed-upload.js
+++ b/lib/managed-upload.js
@@ -15,7 +15,7 @@ const proto = exports;
 /**
  * Upload a file to OSS using multipart uploads
  * @param {String} name
- * @param {String|File} file
+ * @param {String|File|Buffer} file
  * @param {Object} options
  *        {Object} options.callback The callback parameter is composed of a JSON string encoded in Base64
  *        {String} options.callback.url the OSS sends a callback request to this URL
@@ -36,8 +36,15 @@ proto.multipartUpload = async function multipartUpload(name, file, options) {
   }
 
   const minPartSize = 100 * 1024;
-  const filename = isFile(file) ? file.name : file;
-  options.mime = options.mime || mime.getType(path.extname(filename));
+  if (!options.mime) {
+    if (isFile(file)) {
+      options.mime = mime.getType(path.extname(file.name));
+    } else if (is.buffer(file)) {
+      options.mime = '';
+    } else {
+      options.mime = mime.getType(path.extname(file));
+    }
+  }
   options.headers = options.headers || {};
   this._convertMetaToHeaders(options.meta, options.headers);
 
@@ -265,13 +272,22 @@ proto._createStream = function _createStream(file, start, end) {
     return file;
   } else if (isFile(file)) {
     return new WebFileReadStream(file.slice(start, end));
+  } else if (is.buffer(file)) {
+    const iterable = file.subarray(start, end);
+    // we can't use Readable.from() since it is only support in Node v10
+    return new Readable({
+      read() {
+        this.push(iterable);
+        this.push(null);
+      }
+    });
   } else if (is.string(file)) {
     return fs.createReadStream(file, {
       start,
       end: end - 1
     });
   }
-  throw new Error('_createStream requires File/String.');
+  throw new Error('_createStream requires Buffer/File/String.');
 };
 
 proto._getPartSize = function _getPartSize(fileSize, partSize) {

--- a/test/browser/browser.test.js
+++ b/test/browser/browser.test.js
@@ -1071,6 +1071,32 @@ describe('browser', () => {
         assert.deepEqual(md5(object.content), md5(fileBuf));
       });
 
+      it('should upload buffer', async () => {
+        // create a buffer with 1M random data
+        const bufferString = Array(1024 * 1024).fill('a').join('');
+        const fileBuf = Buffer.from(bufferString);
+
+        const name = `${prefix}multipart/upload-buffer`;
+
+        let progress = 0;
+        const result = await store.multipartUpload(name, fileBuf, {
+          partSize: 100 * 1024,
+          progress() {
+            progress++;
+          }
+        });
+        sinon.restore();
+        assert.equal(result.res.status, 200);
+        assert.equal(progress, 12);
+
+        const object = await store.get(name);
+        assert.equal(object.res.status, 200);
+
+        assert.equal(object.content.length, fileBuf.length);
+        // avoid comparing buffers directly for it may hang when generating diffs
+        assert.deepEqual(md5(object.content), md5(fileBuf));
+      });
+
       it('should return requestId in init, upload part, complete', async () => {
         const fileContent = Array(1024 * 1024).fill('a').join('');
         const file = new File([fileContent], 'multipart-fallback');


### PR DESCRIPTION
Allows `.multipartUpload()` to take a [Node.JS Buffer](https://nodejs.org/api/buffer.html#buffer_class_buffer) as a parameter. 

Before, `.multipartUpload` only supported parameter:
  - file {String|File(only support Browser)|Blob(only support Browser)} file path or HTML5 Web File or web Blob

Now, `.multipartUpload` supports parameter:
  - file {String|File(only support Browser)|Blob(only support Browser)|**Buffer**} file path or HTML5 Web File or web Blob or **content buffer**