### PR TITLE
fix: Support empty prefix in putBucketLifecycle

### DIFF
--- a/lib/common/bucket/putBucketLifecycle.js
+++ b/lib/common/bucket/putBucketLifecycle.js
@@ -91,7 +91,7 @@ function handleCheckTag(tag) {
 function checkRule(rule) {
   if (rule.id && getStrBytesCount(rule.id) > 255) throw new Error('ID is composed of 255 bytes at most');
 
-  if (rule.prefix === '' || rule.prefix === undefined) throw new Error('Rule must includes prefix');
+  if (rule.prefix === undefined) throw new Error('Rule must includes prefix');
 
   if (!['Enabled', 'Disabled'].includes(rule.status)) throw new Error('Status must be  Enabled or Disabled');
 

--- a/test/node/bucket.test.js
+++ b/test/node/bucket.test.js
@@ -762,6 +762,18 @@ describe('test/bucket.test.js', () => {
       assert.equal(putresult2.res.status, 200);
     });
 
+    it('should put the lifecycle with empty prefix (whole bucket)', async () => {
+      const putresult = await store.putBucketLifecycle(bucket, [{
+        id: 'abortMultipartUpload1',
+        prefix: '', // empty prefix (whole bucket)
+        status: 'Enabled',
+        abortMultipartUpload: {
+          days: 1
+        }
+      }]);
+      assert.equal(putresult.res.status, 200);
+    });
+
     it('should put the lifecycle with Transition', async () => {
       const putresult1 = await store.putBucketLifecycle(bucket, [{
         id: 'transition',


### PR DESCRIPTION
Using an empty prefix string `""` should be supported in bucket life-cycle: `{prefix: ""}` is supported for rule that applied to whole bucket.

For example, when using the **Whole Bucket/配置到整个 Bucket** option:

![Screenshot from 2020-07-21 00-45-10](https://user-images.githubusercontent.com/19716675/87996948-9e4a0d80-caeb-11ea-90f8-606b90ed6d21.png)

You get the following rule with `getBucketLifeCycle`:

```console
> aliApi.getBucketLifecycle(bucket).then(console.log);
Promise { <pending> }
> {
  rules: [
    {
      prefix: '', // <-- empty prefix here
      status: 'Enabled',
      abortMultipartUpload: [Object],
      id: '******'
    }
  ],
  res: {
    status: 200,
    ...
```
