### PR TITLE
docs: revise `start-after` in listV2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2357,13 +2357,13 @@ const result = await store.listV2({
 console.log(result.objects);
 ```
 
-- List `a/` dir objects, after `a/b` and include `a/b`
+- List `a/` dir objects, after `a/b` and not include `a/b`
 
 ```js
 const result = await store.listV2({
   delimiter: '/',
   prefix: 'a/',
-  'start-after': 'b'
+  'start-after': 'a/b'
 });
 console.log(result.objects);
 ```

--- a/test/browser/browser.test.js
+++ b/test/browser/browser.test.js
@@ -574,7 +574,6 @@ describe('browser', () => {
     });
 
     it('should list with start-afer', async () => {
-      // todo
       let result = await store.listV2({
         'start-after': `${listPrefix}fun`,
         'max-keys': 1
@@ -594,6 +593,29 @@ describe('browser', () => {
       });
       assert(result.objects.length === 1);
       assert(result.objects[0].name === `${listPrefix}fun/movie/007.avi`);
+
+      result = await store.listV2({
+        prefix: `${listPrefix}`,
+        'max-keys': 5,
+        'start-after': `${listPrefix}a`,
+        delimiter: '/'
+      });
+      assert.strictEqual(result.keyCount, 3);
+      assert.strictEqual(result.objects.length, 1);
+      assert.strictEqual(result.objects[0].name, `${listPrefix}oss.jpg`);
+      assert.strictEqual(result.prefixes.length, 2);
+      assert.strictEqual(result.prefixes[0], `${listPrefix}fun/`);
+      assert.strictEqual(result.prefixes[1], `${listPrefix}other/`);
+
+      result = await store.listV2({
+        prefix: `${listPrefix}`,
+        'max-keys': 5,
+        'start-after': `${listPrefix}oss.jpg`,
+        delimiter: '/'
+      });
+      assert.strictEqual(result.keyCount, 1);
+      assert.strictEqual(result.objects, undefined);
+      assert.strictEqual(result.prefixes[0], `${listPrefix}other/`);
     });
 
     it('should list with continuation-token', async () => {

--- a/test/node/object.test.js
+++ b/test/node/object.test.js
@@ -1948,7 +1948,6 @@ describe('test/object.test.js', () => {
     });
 
     it('should list with start-afer', async () => {
-      // todo
       let result = await store.listV2({
         'start-after': `${listPrefix}fun`,
         'max-keys': 1
@@ -1968,6 +1967,29 @@ describe('test/object.test.js', () => {
       });
       assert(result.objects.length === 1);
       assert(result.objects[0].name === `${listPrefix}fun/movie/007.avi`);
+
+      result = await store.listV2({
+        prefix: `${listPrefix}`,
+        'max-keys': 5,
+        'start-after': `${listPrefix}a`,
+        delimiter: '/'
+      });
+      assert.strictEqual(result.keyCount, 3);
+      assert.strictEqual(result.objects.length, 1);
+      assert.strictEqual(result.objects[0].name, `${listPrefix}oss.jpg`);
+      assert.strictEqual(result.prefixes.length, 2);
+      assert.strictEqual(result.prefixes[0], `${listPrefix}fun/`);
+      assert.strictEqual(result.prefixes[1], `${listPrefix}other/`);
+
+      result = await store.listV2({
+        prefix: `${listPrefix}`,
+        'max-keys': 5,
+        'start-after': `${listPrefix}oss.jpg`,
+        delimiter: '/'
+      });
+      assert.strictEqual(result.keyCount, 1);
+      assert.strictEqual(result.objects, undefined);
+      assert.strictEqual(result.prefixes[0], `${listPrefix}other/`);
     });
 
     it('should list with continuation-token', async () => {


### PR DESCRIPTION
revise `start-after` and add test case
修订`start-after`文档 和 增加对应测试用例