### PR TITLE
fix(node): deepCopy not working for large Buffers

### DIFF
--- a/lib/common/utils/deepCopy.js
+++ b/lib/common/utils/deepCopy.js
@@ -1,9 +1,13 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.deepCopy = void 0;
+const isBuffer_1 = require("./isBuffer");
 exports.deepCopy = (obj) => {
     if (obj === null || typeof obj !== 'object') {
         return obj;
+    }
+    if (isBuffer_1.isBuffer(obj)) {
+        return Buffer.from(obj);
     }
     const copy = Array.isArray(obj) ? [] : {};
     Object.keys(obj).forEach((key) => {

--- a/lib/common/utils/deepCopy.ts
+++ b/lib/common/utils/deepCopy.ts
@@ -1,6 +1,11 @@
+import { isBuffer } from './isBuffer';
+
 export const deepCopy = (obj) => {
   if (obj === null || typeof obj !== 'object') {
     return obj;
+  }
+  if (isBuffer(obj)) {
+    return Buffer.from(obj);
   }
 
   const copy = Array.isArray(obj) ? [] : {};

--- a/test/node/utils/deepCopy.test.js
+++ b/test/node/utils/deepCopy.test.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+const { Buffer } = require('buffer');
+const { deepCopy } = require('../../../lib/common/utils/deepCopy');
+
+describe('utils/deepCopy()', () => {
+  it('should copy big Buffers correctly', () => {
+    // 2^30 - 1 ~ 1GB is max size on 32-bit computer
+    // See https://nodejs.org/api/buffer.html#buffer_buffer_constants_max_length
+    const numberBytes = Math.pow(2, 30) - 1;
+    const obj = {
+      buffer: Buffer.alloc(numberBytes),
+    };
+    assert.deepStrictEqual(deepCopy(obj), obj);
+  });
+});


### PR DESCRIPTION
`deepCopy()` does not work when copying an object with a large Buffer (see test case).

This causes issues when using `multipartUpload()` when `file` is a very big `Buffer` (~1GB) and with the `checkpoint` option, since in [completeMultipartUpload](https://github.com/ali-sdk/ali-oss/blob/afaf0ed924ddbbbdaf20eb9c299d44e964cc704c/lib/common/multipart.js#L186) we `deepCopy` all the options.

Example:

```js
const file = Buffer.alloc(Math.pow(2, 30) - 1); // ~ 1GB
const savedCheckpoint = {file, ...} // made from multipartUpload#progress

// throws RangeError in utils/deepCopy, when copying options.checkpoint.file
multipartUpload("name", file, {checkpoint: savedCheckpoint});
```

Copying all `Buffer` in `deepCopy()` using `Buffer.from` seems to fix this issue.