### PR TITLE
fix: spec compatible "browser" mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "ali-oss",
   "version": "6.17.0",
   "description": "aliyun oss(object storage service) node client",
-  "main": "lib/client.js",
+  "main": "./lib/client.js",
   "files": [
     "lib",
     "shims",
     "dist"
   ],
   "browser": {
-    "lib/client.js": "./dist/aliyun-oss-sdk.js",
+    "./lib/client.js": "./dist/aliyun-oss-sdk.js",
     "mime": "mime/lite",
     "urllib": "./shims/xhr.js",
     "utility": "./shims/utility.js",


### PR DESCRIPTION
per unofficial "spec" https://github.com/defunctzombie/package-browser-field-spec
local files should be referenced with `./`. this allows for distinction between package and local file re-mapping.

changed `"main"` as well just for consistency. doesn't really matter there.