### PR TITLE
fix: fix peerDependencies warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "address": "^1.0.0",
     "agentkeepalive": "^3.4.1",
     "bowser": "^1.6.0",
+    "co": "^4.6.0",
     "co-defer": "^1.0.0",
     "copy-to": "^2.0.1",
     "dateformat": "^2.0.0",


### PR DESCRIPTION
`co-deferr`这个库的peerDependencies声明了要`co`这个库。如果不加上这个库，客户安装会告警。