### PR TITLE
fix: remove Invalid Comparison

### DIFF
--- a/lib/common/parallel.js
+++ b/lib/common/parallel.js
@@ -74,7 +74,7 @@ proto._parallel = function _parallel(todo, parallel, jobPromise) {
         done = true;
         _jobErr.push(err);
         resolve(_jobErr);
-      } else if (value === {} || (done && running <= 0)) {
+      } else if (done && running <= 0) {
         done = true;
         resolve(_jobErr);
       } else if (!looping) {


### PR DESCRIPTION
用`esbuild`发现这段代码，跟`{}`对比每次都返回false，因为用得是`||`，所以直接删除就行
<img width="952" alt="image" src="https://user-images.githubusercontent.com/45714422/164145731-9ecb956e-5ea9-469f-8d56-68d274510a7e.png">
