### PR TITLE
fix: fix use store bucket name. getBucketLocation & getBucketInfo

### DIFF
--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -89,9 +89,9 @@ proto.getBucket = function getBucket() {
 };
 
 proto.getBucketLocation = async function getBucketLocation(name, options) {
-  _checkBucketName(name);
-  name = name || this.getBucket();
-  const params = this._bucketRequestParams('GET', name, 'location', options);
+  const _name = name || this.getBucket();
+  _checkBucketName(_name);
+  const params = this._bucketRequestParams('GET', _name, 'location', options);
   params.successStatuses = [200];
   params.xmlResponse = true;
   const result = await this.request(params);
@@ -102,9 +102,9 @@ proto.getBucketLocation = async function getBucketLocation(name, options) {
 };
 
 proto.getBucketInfo = async function getBucketInfo(name, options) {
-  _checkBucketName(name);
-  name = name || this.getBucket();
-  const params = this._bucketRequestParams('GET', name, 'bucketInfo', options);
+  const _name = name || this.getBucket();
+  _checkBucketName(_name);
+  const params = this._bucketRequestParams('GET', _name, 'bucketInfo', options);
   params.successStatuses = [200];
   params.xmlResponse = true;
   const result = await this.request(params);

--- a/test/node/bucket.test.js
+++ b/test/node/bucket.test.js
@@ -136,6 +136,17 @@ describe('test/bucket.test.js', () => {
       assert.equal(result.bucket.StorageClass, 'Standard');
     });
 
+    it('it should return correct bucketInfo when bucket exist by store setting', async () => {
+        const result = await store.getBucketInfo();
+        assert.equal(result.res.status, 200);
+  
+        assert.equal(result.bucket.Location, `${bucketRegion}`);
+        assert.equal(result.bucket.ExtranetEndpoint, `${bucketRegion}.aliyuncs.com`);
+        assert.equal(result.bucket.IntranetEndpoint, `${bucketRegion}-internal.aliyuncs.com`);
+        assert.equal(result.bucket.AccessControlList.Grant, 'private');
+        assert.equal(result.bucket.StorageClass, 'Standard');
+    });
+
     it('it should return NoSuchBucketError when bucket not exist', async () => {
       await utils.throws(async () => {
         await store.getBucketInfo('not-exists-bucket');
@@ -147,6 +158,11 @@ describe('test/bucket.test.js', () => {
     it('it should return loaction this.region', async () => {
       const result = await store.getBucketLocation(bucket);
       assert.equal(result.location, bucketRegion);
+    });
+
+    it('it should return localtion this.region by store setting', async () => {
+        const result = await store.getBucketLocation();
+        assert.equal(result.location, bucketRegion);
     });
 
     it('it should return NoSuchBucketError when bucket not exist', async () => {


### PR DESCRIPTION
在getBucketLocation方法与getBucketInfo方法中，不传入name参数获取bucket并检测储存桶名称的流程出现错误。这个PR修复了该流程。