### PR TITLE
fix: timeout issue

### DIFF
--- a/lib/common/client/initOptions.js
+++ b/lib/common/client/initOptions.js
@@ -32,6 +32,9 @@ module.exports = function (options) {
   if (options.bucket) {
     _checkBucketName(options.bucket);
   }
+  if (!options.timeout) {
+    delete options.timeout;
+  }
   const opts = Object.assign(
     {
       region: 'oss-cn-hangzhou',


### PR DESCRIPTION
### 重现方法
初始化 client 时，options 中 timeout 的值设置为 undefined。
### 预期行为
使用 sdk 中定义的默认 timeout 60000ms。
### 实际情况
没有使用 sdk 中定义的默认 timeout。使用了 urllib 中定义的默认 timeout 5s。
### 修复方式
校验 options 中的 timeout 参数。