### PR TITLE
Solve the http problem by changing the default settings because it should be https by default.

### DIFF
--- a/dist/aliyun-oss-sdk.js
+++ b/dist/aliyun-oss-sdk.js
@@ -3349,7 +3349,7 @@ module.exports = function (options) {
   var opts = Object.assign({
     region: 'oss-cn-hangzhou',
     internal: false,
-    secure: false,
+    secure: true, // Bydefault it should be secure true beacuse otherwise user will receive http instead of https, Alibaba cloud provide https for free so why not use https bydefault.
     timeout: 60000,
     bucket: null,
     endpoint: null,


### PR DESCRIPTION
Normally, when calling the object storage system class and invoking the put function to upload an image file to the bucket, it returns an HTTP URL by default. However, it should be HTTPS by default. This is crucial because some people use it, receive the result URL, and then promptly apply it to their work. When images from the object storage system, which uploads with the default setting 'secure=false,' are displayed on a website, it can make the website appear insecure. For certain websites that request location access, devices like iOS and Android 10, 14 may outright reject it. I believe the default setting should be adjusted to 'true' to address this issue.

This is because, typically, Alibaba Cloud provides HTTPS by default to enhance security. I have consulted with the SA (Solution Architect) of Alibaba Cloud Thailand, and he agrees that the code can be confusing. Many developers who call the library may face the issue of receiving images with HTTP URLs, necessitating them to use '.replace('http','https'). If this is rectified, I am confident it will resolve the problem for many developers.